### PR TITLE
Add raw-mode token highlighting for RGB chat editing

### DIFF
--- a/src/main/java/kamkeel/hextext/mixins/early/impl/client/MixinFontRenderer.java
+++ b/src/main/java/kamkeel/hextext/mixins/early/impl/client/MixinFontRenderer.java
@@ -6,6 +6,8 @@ import kamkeel.hextext.client.LegacyFontRenderContext;
 import kamkeel.hextext.client.LegacyRenderAction;
 import kamkeel.hextext.client.LegacyRenderTextData;
 import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.Gui;
+import net.minecraft.util.MathHelper;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -39,128 +41,168 @@ public abstract class MixinFontRenderer {
     @Shadow private float blue;
     /** Actually blue */
     @Shadow private float green;
+    @Shadow protected float posX;
+    @Shadow protected float posY;
+    @Shadow public int FONT_HEIGHT;
 
     @Shadow(remap = false)
     protected abstract void setColor(float r, float g, float b, float a);
 
     @Unique
-    private LegacyRenderTextData angelica$legacyRenderData;
+    private LegacyRenderTextData hextext$legacyRenderData;
     @Unique
-    private Deque<Integer> angelica$legacyColorStack;
+    private Deque<Integer> hextext$legacyColorStack;
     @Unique
-    private int angelica$legacyBaseColor;
+    private int hextext$legacyBaseColor;
     @Unique
-    private boolean angelica$legacyShadow;
+    private boolean hextext$legacyShadow;
+    @Unique
+    private List<TokenHighlight> hextext$pendingHighlights;
+    @Unique
+    private int hextext$rawTokenSkip;
+    @Unique
+    private boolean hextext$renderingShadow;
 
     @Inject(method = "renderStringAtPos", at = @At("HEAD"))
-    private void angelica$legacy$begin(String text, boolean shadow, CallbackInfo ci) {
-        angelica$legacyRenderData = angelica$prepareRenderData(text);
-        angelica$legacyColorStack = null;
-        angelica$legacyBaseColor = this.textColor;
-        angelica$legacyShadow = shadow;
+    private void hextext$legacy$begin(String text, boolean shadow, CallbackInfo ci) {
+        hextext$legacyRenderData = hextext$prepareRenderData(text);
+        hextext$legacyColorStack = null;
+        hextext$legacyBaseColor = this.textColor;
+        hextext$legacyShadow = shadow;
+        hextext$renderingShadow = shadow;
+        if (!shadow && LegacyFontRenderContext.isRawTextRendering()) {
+            if (hextext$pendingHighlights == null) {
+                hextext$pendingHighlights = new ArrayList<>();
+            } else {
+                hextext$pendingHighlights.clear();
+            }
+        } else if (hextext$pendingHighlights != null) {
+            hextext$pendingHighlights.clear();
+        }
+        hextext$rawTokenSkip = 0;
     }
 
     @ModifyVariable(method = "renderStringAtPos", at = @At("HEAD"), argsOnly = true)
-    private String angelica$legacy$replaceRenderText(String text) {
-        if (angelica$legacyRenderData != null && angelica$legacyRenderData.isModified()) {
-            return angelica$legacyRenderData.getSanitized();
+    private String hextext$legacy$replaceRenderText(String text) {
+        if (hextext$legacyRenderData != null && hextext$legacyRenderData.isModified()) {
+            return hextext$legacyRenderData.getSanitized();
         }
         return text;
     }
 
     @Inject(method = "renderStringAtPos", at = @At(value = "INVOKE_ASSIGN", target = "Ljava/lang/String;charAt(I)C"),
         locals = LocalCapture.CAPTURE_FAILHARD)
-    private void angelica$legacy$applyActions(String text, boolean shadow, CallbackInfo ci, int index, char current) {
-        if (angelica$legacyRenderData == null || angelica$legacyRenderData.getActions() == null) {
+    private void hextext$legacy$applyActions(String text, boolean shadow, CallbackInfo ci, int index, char current) {
+        if (!hextext$renderingShadow && LegacyFontRenderContext.isRawTextRendering()) {
+            if (hextext$rawTokenSkip > 0) {
+                hextext$rawTokenSkip--;
+            } else {
+                int tokenLength = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(text, index);
+                if (tokenLength > 0) {
+                    float width = hextext$measureLiteralWidth(text, index, tokenLength);
+                    if (width > 0.0f && hextext$pendingHighlights != null) {
+                        hextext$pendingHighlights.add(new TokenHighlight(this.posX, this.posY, width,
+                            hextext$getTokenHighlightColor(text, index)));
+                    }
+                    hextext$rawTokenSkip = Math.max(tokenLength - 1, 0);
+                }
+            }
+        }
+
+        if (hextext$legacyRenderData == null || hextext$legacyRenderData.getActions() == null) {
             return;
         }
 
-        List<LegacyRenderAction> actions = angelica$legacyRenderData.getActions().remove(index);
+        List<LegacyRenderAction> actions = hextext$legacyRenderData.getActions().remove(index);
         if (actions == null) {
             return;
         }
 
         for (LegacyRenderAction action : actions) {
-            angelica$execute(action);
+            hextext$execute(action);
         }
     }
 
     @Inject(method = "renderStringAtPos", at = @At("TAIL"))
-    private void angelica$legacy$end(String text, boolean shadow, CallbackInfo ci) {
-        angelica$legacyRenderData = null;
-        angelica$legacyColorStack = null;
+    private void hextext$legacy$end(String text, boolean shadow, CallbackInfo ci) {
+        hextext$legacyRenderData = null;
+        hextext$legacyColorStack = null;
+        if (!hextext$renderingShadow && hextext$pendingHighlights != null && !hextext$pendingHighlights.isEmpty()) {
+            hextext$drawTokenHighlights();
+            hextext$pendingHighlights.clear();
+        }
     }
 
     @Inject(method = "getStringWidth", at = @At("RETURN"), cancellable = true)
-    private void angelica$legacy$width(String text, CallbackInfoReturnable<Integer> cir) {
-        cir.setReturnValue((int) angelica$calculateMaxLineWidth(text));
+    private void hextext$legacy$width(String text, CallbackInfoReturnable<Integer> cir) {
+        cir.setReturnValue((int) hextext$calculateMaxLineWidth(text));
     }
 
     @Inject(method = "sizeStringToWidth", at = @At("RETURN"), cancellable = true)
-    private void angelica$legacy$size(String text, int maxWidth, CallbackInfoReturnable<Integer> cir) {
-        cir.setReturnValue(angelica$computeLineBreakIndex(text, maxWidth));
+    private void hextext$legacy$size(String text, int maxWidth, CallbackInfoReturnable<Integer> cir) {
+        cir.setReturnValue(hextext$computeLineBreakIndex(text, maxWidth));
     }
 
     @Inject(method = "trimStringToWidth(Ljava/lang/String;IZ)Ljava/lang/String;", at = @At("RETURN"), cancellable = true)
-    private void angelica$legacy$trim(String text, int width, boolean reverse, CallbackInfoReturnable<String> cir) {
+    private void hextext$legacy$trim(String text, int width, boolean reverse, CallbackInfoReturnable<String> cir) {
         if (text == null || text.isEmpty()) {
             cir.setReturnValue("");
             return;
         }
 
         if (!reverse) {
-            int endIndex = angelica$computeLineBreakIndex(text, width);
+            int endIndex = hextext$computeLineBreakIndex(text, width);
             cir.setReturnValue(text.substring(0, Math.min(endIndex, text.length())));
             return;
         }
 
-        cir.setReturnValue(angelica$trimFromEnd(text, width));
+        cir.setReturnValue(hextext$trimFromEnd(text, width));
     }
 
     @Inject(method = "wrapFormattedStringToWidth", at = @At("RETURN"), cancellable = true)
-    private void angelica$legacy$wrap(String text, int width, CallbackInfoReturnable<String> cir) {
+    private void hextext$legacy$wrap(String text, int width, CallbackInfoReturnable<String> cir) {
         if (text == null || text.isEmpty()) {
             cir.setReturnValue("");
             return;
         }
 
-        cir.setReturnValue(angelica$wrapFormattedStringToWidth(text, width));
+        cir.setReturnValue(hextext$wrapFormattedStringToWidth(text, width));
     }
 
     @Inject(method = "getFormatFromString", at = @At("RETURN"), cancellable = true)
-    private static void angelica$legacy$format(String text, CallbackInfoReturnable<String> cir) {
+    private static void hextext$legacy$format(String text, CallbackInfoReturnable<String> cir) {
         cir.setReturnValue(ColorCodeUtils.extractFormatFromString(text));
     }
 
     @Unique
-    private void angelica$execute(LegacyRenderAction action) {
+    private void hextext$execute(LegacyRenderAction action) {
         switch (action.getType()) {
             case APPLY_RGB:
-                if (action.shouldClearStack() && angelica$legacyColorStack != null) {
-                    angelica$legacyColorStack.clear();
+                if (action.shouldClearStack() && hextext$legacyColorStack != null) {
+                    hextext$legacyColorStack.clear();
                 }
-                angelica$applyRgbColor(action.getRgb(), angelica$legacyShadow);
-                angelica$resetFormattingStyles();
+                hextext$applyRgbColor(action.getRgb(), hextext$legacyShadow);
+                hextext$resetFormattingStyles();
                 break;
             case PUSH_RGB:
-                if (angelica$legacyColorStack == null) {
-                    angelica$legacyColorStack = new ArrayDeque<>();
+                if (hextext$legacyColorStack == null) {
+                    hextext$legacyColorStack = new ArrayDeque<>();
                 }
-                angelica$legacyColorStack.push(this.textColor);
-                angelica$applyRgbColor(action.getRgb(), angelica$legacyShadow);
+                hextext$legacyColorStack.push(this.textColor);
+                hextext$applyRgbColor(action.getRgb(), hextext$legacyShadow);
                 break;
             case POP_COLOR:
-                if (angelica$legacyColorStack != null && !angelica$legacyColorStack.isEmpty()) {
-                    angelica$setColorFromInt(angelica$legacyColorStack.pop());
+                if (hextext$legacyColorStack != null && !hextext$legacyColorStack.isEmpty()) {
+                    hextext$setColorFromInt(hextext$legacyColorStack.pop());
                 } else {
-                    angelica$setColorFromInt(angelica$legacyBaseColor);
+                    hextext$setColorFromInt(hextext$legacyBaseColor);
                 }
                 break;
         }
     }
 
     @Unique
-    private void angelica$setColorFromInt(int rgb) {
+    private void hextext$setColorFromInt(int rgb) {
         this.textColor = rgb;
         setColor((float) (rgb >> 16 & 255) / 255.0F,
             (float) (rgb >> 8 & 255) / 255.0F,
@@ -169,13 +211,13 @@ public abstract class MixinFontRenderer {
     }
 
     @Unique
-    private void angelica$applyRgbColor(int rgb, boolean shadow) {
+    private void hextext$applyRgbColor(int rgb, boolean shadow) {
         int effective = shadow ? ColorCodeUtils.calculateShadowColor(rgb) : rgb;
-        angelica$setColorFromInt(effective);
+        hextext$setColorFromInt(effective);
     }
 
     @Unique
-    private void angelica$resetFormattingStyles() {
+    private void hextext$resetFormattingStyles() {
         this.randomStyle = false;
         this.boldStyle = false;
         this.strikethroughStyle = false;
@@ -184,7 +226,7 @@ public abstract class MixinFontRenderer {
     }
 
     @Unique
-    private LegacyRenderTextData angelica$prepareRenderData(String text) {
+    private LegacyRenderTextData hextext$prepareRenderData(String text) {
         if (text == null || text.isEmpty() || LegacyFontRenderContext.isRawTextRendering()) {
             return LegacyRenderTextData.unmodified(text);
         }
@@ -258,7 +300,75 @@ public abstract class MixinFontRenderer {
     }
 
     @Unique
-    private float angelica$getCharWidthFloat(char chr) {
+    private float hextext$measureLiteralWidth(CharSequence text, int start, int length) {
+        if (length <= 0 || start < 0 || start >= text.length()) {
+            return 0.0f;
+        }
+        int end = Math.min(start + length, text.length());
+        if (end <= start) {
+            return 0.0f;
+        }
+        String segment = text.subSequence(start, end).toString();
+        return ((FontRenderer) (Object) this).getStringWidth(segment);
+    }
+
+    @Unique
+    private int hextext$getTokenHighlightColor(CharSequence text, int index) {
+        char c = text.charAt(index);
+        if (c == 167 || (c == '&' && index + 1 < text.length() && ColorCodeUtils.isFormattingCode(text.charAt(index + 1)))) {
+            return 0x304080FF;
+        }
+        if (c == '&') {
+            return 0x3039C86F;
+        }
+        if (c == '<') {
+            if (index + 1 < text.length() && text.charAt(index + 1) == '/') {
+                return 0x30FF8C5A;
+            }
+            return 0x305A8CFF;
+        }
+        return 0x30222222;
+    }
+
+    @Unique
+    private void hextext$drawTokenHighlights() {
+        for (TokenHighlight highlight : hextext$pendingHighlights) {
+            hextext$drawTokenHighlight(highlight);
+        }
+    }
+
+    @Unique
+    private void hextext$drawTokenHighlight(TokenHighlight highlight) {
+        float left = highlight.x;
+        float right = highlight.x + highlight.width;
+        float top = highlight.y - 1.0f;
+        float bottom = highlight.y + this.FONT_HEIGHT;
+
+        int x1 = MathHelper.floor_float(left);
+        int y1 = MathHelper.floor_float(top);
+        int x2 = MathHelper.ceiling_float_int(right);
+        int y2 = MathHelper.ceiling_float_int(bottom);
+
+        Gui.drawRect(x1, y1, x2, y2, highlight.color);
+    }
+
+    @Unique
+    private static final class TokenHighlight {
+        private final float x;
+        private final float y;
+        private final float width;
+        private final int color;
+
+        private TokenHighlight(float x, float y, float width, int color) {
+            this.x = x;
+            this.y = y;
+            this.width = width;
+            this.color = color;
+        }
+    }
+
+    @Unique
+    private float hextext$getCharWidthFloat(char chr) {
         if (chr == 167) {
             return 0.0f;
         }
@@ -267,7 +377,7 @@ public abstract class MixinFontRenderer {
     }
 
     @Unique
-    private float angelica$calculateMaxLineWidth(String text) {
+    private float hextext$calculateMaxLineWidth(String text) {
         if (text == null || text.isEmpty()) {
             return 0.0f;
         }
@@ -305,7 +415,7 @@ public abstract class MixinFontRenderer {
                 continue;
             }
 
-            float width = angelica$getCharWidthFloat(chr);
+            float width = hextext$getCharWidthFloat(chr);
             lineWidth += width;
             if (bold && width > 0.0f) {
                 lineWidth += 1.0f;
@@ -317,13 +427,13 @@ public abstract class MixinFontRenderer {
     }
 
     @Unique
-    private int angelica$computeLineBreakIndex(String text, int maxWidth) {
+    private int hextext$computeLineBreakIndex(String text, int maxWidth) {
         return FormattedTextMetrics.computeLineBreakIndex(text, maxWidth,
-            LegacyFontRenderContext.isRawTextRendering(), this::angelica$getCharWidthFloat, 0.0f, 1.0f);
+            LegacyFontRenderContext.isRawTextRendering(), this::hextext$getCharWidthFloat, 0.0f, 1.0f);
     }
 
     @Unique
-    private String angelica$trimFromEnd(String text, int width) {
+    private String hextext$trimFromEnd(String text, int width) {
         final boolean rawMode = LegacyFontRenderContext.isRawTextRendering();
         float currentWidth = 0.0f;
         int firstSafePosition = text.length();
@@ -402,7 +512,7 @@ public abstract class MixinFontRenderer {
                 return text.substring(index + 1);
             }
 
-            float glyphWidth = angelica$getCharWidthFloat(chr);
+            float glyphWidth = hextext$getCharWidthFloat(chr);
             if (glyphWidth < 0.0f) {
                 glyphWidth = 0.0f;
             }
@@ -425,8 +535,8 @@ public abstract class MixinFontRenderer {
     }
 
     @Unique
-    private String angelica$wrapFormattedStringToWidth(String text, int wrapWidth) {
-        int breakPoint = angelica$computeLineBreakIndex(text, wrapWidth);
+    private String hextext$wrapFormattedStringToWidth(String text, int wrapWidth) {
+        int breakPoint = hextext$computeLineBreakIndex(text, wrapWidth);
 
         if (breakPoint >= text.length()) {
             return text;
@@ -443,6 +553,6 @@ public abstract class MixinFontRenderer {
             return firstPart + "\n" + remainder;
         }
 
-        return firstPart + "\n" + angelica$wrapFormattedStringToWidth(remainder, wrapWidth);
+        return firstPart + "\n" + hextext$wrapFormattedStringToWidth(remainder, wrapWidth);
     }
 }

--- a/src/main/java/kamkeel/hextext/mixins/early/impl/client/MixinGuiTextField.java
+++ b/src/main/java/kamkeel/hextext/mixins/early/impl/client/MixinGuiTextField.java
@@ -12,19 +12,19 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class MixinGuiTextField {
 
     @Unique
-    private boolean angelica$legacy$rawPushed;
+    private boolean hextext$legacy$rawPushed;
 
     @Inject(method = "drawTextBox", at = @At("HEAD"))
-    private void angelica$legacy$beginRawMode(CallbackInfo ci) {
+    private void hextext$legacy$beginRawMode(CallbackInfo ci) {
         LegacyFontRenderContext.pushRawTextRendering();
-        angelica$legacy$rawPushed = true;
+        hextext$legacy$rawPushed = true;
     }
 
     @Inject(method = "drawTextBox", at = @At("RETURN"))
-    private void angelica$legacy$endRawMode(CallbackInfo ci) {
-        if (angelica$legacy$rawPushed) {
+    private void hextext$legacy$endRawMode(CallbackInfo ci) {
+        if (hextext$legacy$rawPushed) {
             LegacyFontRenderContext.popRawTextRendering();
-            angelica$legacy$rawPushed = false;
+            hextext$legacy$rawPushed = false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- rename mixin helper members to use a HexText prefix instead of Angelica
- add raw-mode token highlight tracking to the legacy FontRenderer mixin so chat text boxes show RGB tokens

## Testing
- not run (Gradle decompilation task is very slow in this environment)


------
https://chatgpt.com/codex/tasks/task_e_6901338b35b083238d0ce970105b9a2f