### PR TITLE
Normalize raw chat color code rendering

### DIFF
--- a/src/main/java/kamkeel/hextext/ColorCodeUtils.java
+++ b/src/main/java/kamkeel/hextext/ColorCodeUtils.java
@@ -78,6 +78,39 @@ public class ColorCodeUtils {
         return detectColorCodeLengthInternal(str, pos, false);
     }
 
+    public static String normalizeForRawDisplay(String text) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+
+        StringBuilder builder = null;
+
+        for (int i = 0; i < text.length(); i++) {
+            char current = text.charAt(i);
+
+            if (current == 167) {
+                if (builder == null) {
+                    builder = new StringBuilder(text.length() + 8);
+                    builder.append(text, 0, i);
+                }
+
+                if (i + 1 < text.length()) {
+                    builder.append('&');
+                    builder.append(text.charAt(++i));
+                } else {
+                    builder.append('§');
+                }
+                continue;
+            }
+
+            if (builder != null) {
+                builder.append(current);
+            }
+        }
+
+        return builder == null ? text : builder.toString();
+    }
+
     private static int detectColorCodeLengthInternal(CharSequence str, int pos, boolean skipDueToRaw) {
         if (str == null || pos < 0 || pos >= str.length()) {
             return 0;

--- a/src/main/java/kamkeel/hextext/mixins/early/impl/client/MixinFontRenderer.java
+++ b/src/main/java/kamkeel/hextext/mixins/early/impl/client/MixinFontRenderer.java
@@ -85,6 +85,9 @@ public abstract class MixinFontRenderer {
 
     @ModifyVariable(method = "renderStringAtPos", at = @At("HEAD"), argsOnly = true)
     private String hextext$legacy$replaceRenderText(String text) {
+        if (LegacyFontRenderContext.isRawTextRendering()) {
+            return ColorCodeUtils.normalizeForRawDisplay(text);
+        }
         if (hextext$legacyRenderData != null && hextext$legacyRenderData.isModified()) {
             return hextext$legacyRenderData.getSanitized();
         }
@@ -356,6 +359,9 @@ public abstract class MixinFontRenderer {
     @Unique
     private float hextext$getCharWidthFloat(char chr) {
         if (chr == 167) {
+            if (LegacyFontRenderContext.isRawTextRendering()) {
+                return ((FontRenderer) (Object) this).getCharWidth('&');
+            }
             return 0.0f;
         }
         int width = ((FontRenderer) (Object) this).getCharWidth(chr);


### PR DESCRIPTION
## Summary
- normalize raw chat rendering by converting section sign formatting codes to ampersand sequences so raw mode shows literal tokens without applying formatting
- ensure character width calculations treat section signs as visible glyphs during raw rendering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6901393804888323a4057d1ec7863b6c