### PR TITLE
Add animated text effects for rainbow, dinnerbone, ignite, and shake

### DIFF
--- a/src/main/java/kamkeel/hextext/client/RenderInstruction.java
+++ b/src/main/java/kamkeel/hextext/client/RenderInstruction.java
@@ -15,7 +15,12 @@ public final class RenderInstruction {
         SET_BOLD,
         SET_STRIKETHROUGH,
         SET_UNDERLINE,
-        SET_ITALIC
+        SET_ITALIC,
+        SET_RAINBOW,
+        SET_DINNERBONE,
+        SET_IGNITE,
+        SET_SHAKE,
+        RESET_EFFECTS
     }
 
     private final Type type;
@@ -73,6 +78,26 @@ public final class RenderInstruction {
 
     public static RenderInstruction setItalic(boolean enabled) {
         return new RenderInstruction(Type.SET_ITALIC, 0, false, 0, enabled, false);
+    }
+
+    public static RenderInstruction setRainbow(boolean enabled) {
+        return new RenderInstruction(Type.SET_RAINBOW, 0, false, 0, enabled, false);
+    }
+
+    public static RenderInstruction setDinnerbone(boolean enabled) {
+        return new RenderInstruction(Type.SET_DINNERBONE, 0, false, 0, enabled, false);
+    }
+
+    public static RenderInstruction setIgnite(boolean enabled) {
+        return new RenderInstruction(Type.SET_IGNITE, 0, false, 0, enabled, false);
+    }
+
+    public static RenderInstruction setShake(boolean enabled) {
+        return new RenderInstruction(Type.SET_SHAKE, 0, false, 0, enabled, false);
+    }
+
+    public static RenderInstruction resetEffects() {
+        return new RenderInstruction(Type.RESET_EFFECTS, 0, false, 0, false, false);
     }
 
     public Type getType() {

--- a/src/main/java/kamkeel/hextext/client/RenderTextProcessor.java
+++ b/src/main/java/kamkeel/hextext/client/RenderTextProcessor.java
@@ -48,12 +48,13 @@ public final class RenderTextProcessor {
                 }
 
                 if (ColorCodeUtils.isFormattingCode(next)) {
-                    boolean isReset = ColorCodeUtils.isResetCode(next);
+                    char lower = Character.toLowerCase(next);
+                    boolean isReset = ColorCodeUtils.isResetCode(lower);
+
                     if (rawMode) {
                         instructions = ensureInstructionMap(instructions);
                         List<RenderInstruction> bucket =
                             instructions.computeIfAbsent(instructionIndex, key -> new ArrayList<>());
-                        char lower = Character.toLowerCase(next);
                         if (ColorCodeUtils.isMinecraftColorCode(lower)) {
                             int colorIndex = ColorCodeUtils.getMinecraftColorIndex(lower);
                             if (colorIndex >= 0) {
@@ -81,11 +82,26 @@ public final class RenderTextProcessor {
                                 default:
                                     break;
                             }
+                        } else if (ColorCodeUtils.isHexTextEffectCode(lower)) {
+                            appendEffectInstruction(bucket, lower);
                         }
                         sanitized.append('&').append(next);
                         i++;
                         continue;
                     } else {
+                        List<RenderInstruction> bucket = null;
+                        if (ColorCodeUtils.isHexTextEffectCode(lower)) {
+                            instructions = ensureInstructionMap(instructions);
+                            bucket = instructions.computeIfAbsent(instructionIndex, key -> new ArrayList<>());
+                            appendEffectInstruction(bucket, lower);
+                        }
+                        if (isReset || ColorCodeUtils.isMinecraftColorCode(lower)) {
+                            instructions = ensureInstructionMap(instructions);
+                            if (bucket == null) {
+                                bucket = instructions.computeIfAbsent(instructionIndex, key -> new ArrayList<>());
+                            }
+                            bucket.add(RenderInstruction.resetEffects());
+                        }
                         sanitized.append('§');
                         modified = true;
                         continue;
@@ -150,5 +166,24 @@ public final class RenderTextProcessor {
     private static Map<Integer, List<RenderInstruction>> normalizeInstructions(
             Map<Integer, List<RenderInstruction>> instructions) {
         return (instructions == null || instructions.isEmpty()) ? null : instructions;
+    }
+
+    private static void appendEffectInstruction(List<RenderInstruction> bucket, char lower) {
+        switch (Character.toLowerCase(lower)) {
+            case 'g':
+                bucket.add(RenderInstruction.setRainbow(true));
+                break;
+            case 'h':
+                bucket.add(RenderInstruction.setDinnerbone(true));
+                break;
+            case 'i':
+                bucket.add(RenderInstruction.setIgnite(true));
+                break;
+            case 'j':
+                bucket.add(RenderInstruction.setShake(true));
+                break;
+            default:
+                break;
+        }
     }
 }

--- a/src/main/java/kamkeel/hextext/client/TextEffectController.java
+++ b/src/main/java/kamkeel/hextext/client/TextEffectController.java
@@ -1,0 +1,174 @@
+package kamkeel.hextext.client;
+
+import kamkeel.hextext.util.ColorCodeUtils;
+import net.minecraft.client.Minecraft;
+import org.lwjgl.opengl.GL11;
+
+import java.util.Random;
+
+/**
+ * Tracks and applies HexText-specific animated text effects during rendering.
+ */
+public final class TextEffectController {
+
+    private static final float RAINBOW_SPACING_DEGREES = 12.0f;
+    private static final float RAINBOW_SPEED_DEGREES_PER_MS = 0.08f;
+    private static final long IGNITE_PERIOD_MS = 200L;
+    private static final float SHAKE_AMPLITUDE = 0.8f;
+    private static final long SHAKE_PHASE_MS = 30L;
+
+    private final Random random = new Random();
+
+    private boolean rainbowActive;
+    private boolean dinnerboneActive;
+    private boolean igniteActive;
+    private boolean shakeActive;
+
+    private int rainbowStartGlyph;
+    private long rainbowStartTime;
+    private long igniteStartTime;
+    private long shakeSeed;
+
+    public void begin() {
+        resetEffects();
+        shakeSeed = Minecraft.getSystemTime();
+    }
+
+    public void resetEffects() {
+        rainbowActive = false;
+        dinnerboneActive = false;
+        igniteActive = false;
+        shakeActive = false;
+        rainbowStartGlyph = 0;
+        rainbowStartTime = 0L;
+        igniteStartTime = 0L;
+        shakeSeed = Minecraft.getSystemTime();
+    }
+
+    public void applyInstruction(RenderInstruction instruction, int glyphIndex) {
+        switch (instruction.getType()) {
+            case SET_RAINBOW:
+                rainbowActive = instruction.isEnabled();
+                if (rainbowActive) {
+                    rainbowStartGlyph = glyphIndex;
+                    rainbowStartTime = Minecraft.getSystemTime();
+                }
+                break;
+            case SET_DINNERBONE:
+                dinnerboneActive = instruction.isEnabled();
+                break;
+            case SET_IGNITE:
+                igniteActive = instruction.isEnabled();
+                if (igniteActive && igniteStartTime == 0L) {
+                    igniteStartTime = Minecraft.getSystemTime();
+                } else if (!igniteActive) {
+                    igniteStartTime = 0L;
+                }
+                break;
+            case SET_SHAKE:
+                shakeActive = instruction.isEnabled();
+                if (shakeActive) {
+                    shakeSeed = Minecraft.getSystemTime();
+                }
+                break;
+            case RESET_EFFECTS:
+                resetEffects();
+                break;
+            default:
+                break;
+        }
+
+        if (!rainbowActive) {
+            rainbowStartTime = 0L;
+        }
+        if (!shakeActive) {
+            shakeSeed = Minecraft.getSystemTime();
+        }
+        if (!igniteActive) {
+            igniteStartTime = 0L;
+        }
+    }
+
+    public GlyphEffects beforeGlyph(int glyphIndex, int baseColor) {
+        if (!rainbowActive && !igniteActive && !dinnerboneActive && !shakeActive) {
+            return null;
+        }
+
+        long now = Minecraft.getSystemTime();
+        Integer colorOverride = null;
+
+        if (rainbowActive) {
+            float baseHue = (now - rainbowStartTime) * RAINBOW_SPEED_DEGREES_PER_MS;
+            float hue = baseHue + (glyphIndex - rainbowStartGlyph) * RAINBOW_SPACING_DEGREES;
+            colorOverride = ColorCodeUtils.hsvToRgb(hue, 1.0f, 1.0f);
+        } else if (igniteActive) {
+            if (igniteStartTime == 0L) {
+                igniteStartTime = now;
+            }
+            long phase = (now - igniteStartTime) / IGNITE_PERIOD_MS;
+            if ((phase & 1L) == 1L) {
+                int dark = ColorCodeUtils.calculateShadowColor(baseColor);
+                if (dark != baseColor) {
+                    colorOverride = dark;
+                }
+            }
+        }
+
+        float offsetX = 0.0f;
+        float offsetY = 0.0f;
+        if (shakeActive) {
+            long phase = now / SHAKE_PHASE_MS;
+            random.setSeed(shakeSeed + glyphIndex * 341873128712L + phase * 132897987541L);
+            offsetX = (random.nextFloat() - 0.5f) * 2.0f * SHAKE_AMPLITUDE;
+            offsetY = (random.nextFloat() - 0.5f) * 2.0f * SHAKE_AMPLITUDE;
+        }
+
+        return new GlyphEffects(colorOverride, dinnerboneActive, offsetX, offsetY);
+    }
+
+    public static final class GlyphEffects {
+        private final Integer colorOverride;
+        private final boolean dinnerbone;
+        private final float offsetX;
+        private final float offsetY;
+        private final boolean hasTransform;
+        private boolean appliedTransform;
+
+        GlyphEffects(Integer colorOverride, boolean dinnerbone, float offsetX, float offsetY) {
+            this.colorOverride = colorOverride;
+            this.dinnerbone = dinnerbone;
+            this.offsetX = offsetX;
+            this.offsetY = offsetY;
+            this.hasTransform = dinnerbone || offsetX != 0.0f || offsetY != 0.0f;
+        }
+
+        public Integer getColorOverride() {
+            return colorOverride;
+        }
+
+        public void begin(float posX, float posY, int fontHeight) {
+            if (!hasTransform) {
+                appliedTransform = false;
+                return;
+            }
+
+            appliedTransform = true;
+            GL11.glPushMatrix();
+            GL11.glTranslatef(posX, posY, 0.0F);
+            if (offsetX != 0.0f || offsetY != 0.0f) {
+                GL11.glTranslatef(offsetX, offsetY, 0.0F);
+            }
+            if (dinnerbone) {
+                GL11.glTranslatef(0.0F, fontHeight, 0.0F);
+                GL11.glScalef(1.0F, -1.0F, 1.0F);
+            }
+            GL11.glTranslatef(-posX, -posY, 0.0F);
+        }
+
+        public void end() {
+            if (appliedTransform) {
+                GL11.glPopMatrix();
+            }
+        }
+    }
+}

--- a/src/main/java/kamkeel/hextext/mixins/early/impl/client/MixinFontRenderer.java
+++ b/src/main/java/kamkeel/hextext/mixins/early/impl/client/MixinFontRenderer.java
@@ -5,6 +5,7 @@ import kamkeel.hextext.client.FontRendererUtils;
 import kamkeel.hextext.client.RenderInstruction;
 import kamkeel.hextext.client.RenderTextData;
 import kamkeel.hextext.client.RenderTextProcessor;
+import kamkeel.hextext.client.TextEffectController;
 import kamkeel.hextext.client.TokenHighlight;
 import kamkeel.hextext.client.TokenHighlightUtils;
 import kamkeel.hextext.util.ColorCodeUtils;
@@ -16,6 +17,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
@@ -49,6 +51,12 @@ public abstract class MixinFontRenderer {
     @Shadow(remap = false)
     protected abstract void setColor(float r, float g, float b, float a);
 
+    @Shadow
+    protected abstract float renderDefaultChar(int character, boolean italic);
+
+    @Shadow
+    protected abstract float renderUnicodeChar(char character, boolean italic);
+
     @Unique
     private RenderTextData hextext$renderData;
     @Unique
@@ -63,6 +71,10 @@ public abstract class MixinFontRenderer {
     private int hextext$rawTokenSkip;
     @Unique
     private boolean hextext$renderingShadow;
+    @Unique
+    private TextEffectController hextext$effects;
+    @Unique
+    private int hextext$glyphIndex;
 
     @Inject(method = "renderStringAtPos", at = @At("HEAD"))
     private void hextext$begin(String text, boolean shadow, CallbackInfo ci) {
@@ -72,6 +84,11 @@ public abstract class MixinFontRenderer {
         hextext$baseColor = this.textColor;
         hextext$shadow = shadow;
         hextext$renderingShadow = shadow;
+        if (hextext$effects == null) {
+            hextext$effects = new TextEffectController();
+        }
+        hextext$effects.begin();
+        hextext$glyphIndex = 0;
         if (rawMode) {
             hextext$resetFormattingStyles();
         }
@@ -134,10 +151,58 @@ public abstract class MixinFontRenderer {
     private void hextext$end(String text, boolean shadow, CallbackInfo ci) {
         hextext$renderData = null;
         hextext$colorStack = null;
+        hextext$resetEffects();
         if (!hextext$renderingShadow && hextext$pendingHighlights != null && !hextext$pendingHighlights.isEmpty()) {
             TokenHighlightUtils.drawHighlights(hextext$pendingHighlights, this.FONT_HEIGHT);
             hextext$pendingHighlights.clear();
         }
+    }
+
+    @Redirect(method = "renderStringAtPos", at = @At(value = "INVOKE",
+        target = "Lnet/minecraft/client/gui/FontRenderer;renderDefaultChar(IZ)F"))
+    private float hextext$renderDefaultChar(FontRenderer instance, int character, boolean italic) {
+        return hextext$renderGlyph(false, character, italic);
+    }
+
+    @Redirect(method = "renderStringAtPos", at = @At(value = "INVOKE",
+        target = "Lnet/minecraft/client/gui/FontRenderer;renderUnicodeChar(CZ)F"))
+    private float hextext$renderUnicodeChar(FontRenderer instance, char character, boolean italic) {
+        return hextext$renderGlyph(true, character, italic);
+    }
+
+    @Unique
+    private float hextext$renderGlyph(boolean unicode, int codePoint, boolean italic) {
+        TextEffectController.GlyphEffects glyphEffects = null;
+        Integer override = null;
+        if (hextext$effects != null) {
+            glyphEffects = hextext$effects.beforeGlyph(hextext$glyphIndex, this.textColor);
+            if (glyphEffects != null) {
+                override = glyphEffects.getColorOverride();
+            }
+        }
+
+        int previousColor = this.textColor;
+        if (override != null) {
+            hextext$applyRgbColor(override, hextext$renderingShadow);
+        }
+
+        if (glyphEffects != null) {
+            glyphEffects.begin(this.posX, this.posY, this.FONT_HEIGHT);
+        }
+
+        float width = unicode ? renderUnicodeChar((char) codePoint, italic)
+            : renderDefaultChar(codePoint, italic);
+
+        if (glyphEffects != null) {
+            glyphEffects.end();
+        }
+
+        if (override != null) {
+            hextext$setColorFromInt(previousColor);
+        }
+
+        hextext$glyphIndex++;
+        return width;
     }
 
     @Inject(method = "getStringWidth", at = @At("RETURN"), cancellable = true)
@@ -238,6 +303,15 @@ public abstract class MixinFontRenderer {
             case SET_ITALIC:
                 this.italicStyle = instruction.isEnabled();
                 break;
+            case SET_RAINBOW:
+            case SET_DINNERBONE:
+            case SET_IGNITE:
+            case SET_SHAKE:
+            case RESET_EFFECTS:
+                if (hextext$effects != null) {
+                    hextext$effects.applyInstruction(instruction, hextext$glyphIndex);
+                }
+                break;
         }
 
         if (instruction.resetsFormatting()) {
@@ -278,6 +352,14 @@ public abstract class MixinFontRenderer {
         this.strikethroughStyle = false;
         this.underlineStyle = false;
         this.italicStyle = false;
+        hextext$resetEffects();
+    }
+
+    @Unique
+    private void hextext$resetEffects() {
+        if (hextext$effects != null) {
+            hextext$effects.resetEffects();
+        }
     }
 
 }

--- a/src/main/java/kamkeel/hextext/util/ColorCodeUtils.java
+++ b/src/main/java/kamkeel/hextext/util/ColorCodeUtils.java
@@ -38,8 +38,7 @@ public final class ColorCodeUtils {
     public static boolean isFormattingCode(char c) {
         char lower = Character.toLowerCase(c);
         return isMinecraftColorCode(lower)
-            || lower == 'g'
-            || lower == 'h'
+            || isHexTextEffectCode(lower)
             || isStyleCode(lower)
             || isResetCode(lower);
     }
@@ -63,6 +62,11 @@ public final class ColorCodeUtils {
     public static boolean isStyleCode(char c) {
         char lower = Character.toLowerCase(c);
         return lower == 'k' || lower == 'l' || lower == 'm' || lower == 'n' || lower == 'o';
+    }
+
+    public static boolean isHexTextEffectCode(char c) {
+        char lower = Character.toLowerCase(c);
+        return lower == 'g' || lower == 'h' || lower == 'i' || lower == 'j';
     }
 
     public static boolean isResetCode(char c) {


### PR DESCRIPTION
## Summary
- add render instruction types for rainbow, dinnerbone, ignite, shake, and effect resets
- extend the text pre-processor to emit the new instructions while preserving vanilla resets
- integrate a TextEffectController that applies animated colours and transforms via the font renderer mixin

## Testing
- `./gradlew check --console=plain` *(fails: decompileSrgJar missing mc.jar during fernflower decompilation)*

------
https://chatgpt.com/codex/tasks/task_e_69014d0f4f708323984b016726646b89