### PR TITLE
Fix dynamic text effects

### DIFF
--- a/src/main/java/kamkeel/hextext/CommonProxy.java
+++ b/src/main/java/kamkeel/hextext/CommonProxy.java
@@ -1,21 +1,29 @@
 package kamkeel.hextext;
 
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import kamkeel.hextext.config.HexTextConfig;
+import kamkeel.hextext.config.HexTextConfigEventHandler;
+
 public class CommonProxy {
     public static final Logger LOGGER = LogManager.getLogger(HexText.ID);
+    private static boolean eventsRegistered;
 
     public static void eventsInit() {
-
-
+        if (!eventsRegistered) {
+            FMLCommonHandler.instance().bus().register(new HexTextConfigEventHandler());
+            eventsRegistered = true;
+        }
     }
 
     public void preInit(FMLPreInitializationEvent ev) {
+        HexTextConfig.init(ev.getSuggestedConfigurationFile());
         eventsInit();
     }
 

--- a/src/main/java/kamkeel/hextext/HexText.java
+++ b/src/main/java/kamkeel/hextext/HexText.java
@@ -14,7 +14,8 @@ import cpw.mods.fml.relauncher.Side;
 @Mod(
     modid = HexText.ID,
     name = HexText.NAME,
-    version = HexText.VERSION
+    version = HexText.VERSION,
+    guiFactory = "kamkeel.hextext.config.HexTextGuiFactory"
 )
 public class HexText {
 

--- a/src/main/java/kamkeel/hextext/client/RenderInstruction.java
+++ b/src/main/java/kamkeel/hextext/client/RenderInstruction.java
@@ -15,7 +15,11 @@ public final class RenderInstruction {
         SET_BOLD,
         SET_STRIKETHROUGH,
         SET_UNDERLINE,
-        SET_ITALIC
+        SET_ITALIC,
+        SET_RAINBOW,
+        SET_DINNERBONE,
+        SET_IGNITE,
+        SET_SHAKE
     }
 
     private final Type type;
@@ -73,6 +77,22 @@ public final class RenderInstruction {
 
     public static RenderInstruction setItalic(boolean enabled) {
         return new RenderInstruction(Type.SET_ITALIC, 0, false, 0, enabled, false);
+    }
+
+    public static RenderInstruction setRainbow(boolean enabled, int anchorIndex) {
+        return new RenderInstruction(Type.SET_RAINBOW, 0, true, anchorIndex, enabled, false);
+    }
+
+    public static RenderInstruction setDinnerbone(boolean enabled) {
+        return new RenderInstruction(Type.SET_DINNERBONE, 0, false, 0, enabled, false);
+    }
+
+    public static RenderInstruction setIgnite(boolean enabled) {
+        return new RenderInstruction(Type.SET_IGNITE, 0, false, 0, enabled, false);
+    }
+
+    public static RenderInstruction setShake(boolean enabled) {
+        return new RenderInstruction(Type.SET_SHAKE, 0, false, 0, enabled, false);
     }
 
     public Type getType() {

--- a/src/main/java/kamkeel/hextext/client/RenderTextProcessor.java
+++ b/src/main/java/kamkeel/hextext/client/RenderTextProcessor.java
@@ -41,6 +41,8 @@ public final class RenderTextProcessor {
                         if (rawMode) {
                             sanitized.append('&');
                             sanitized.append(processed, i + 1, i + 7);
+                        } else {
+                            modified = true;
                         }
                         i += 6;
                         continue;
@@ -48,12 +50,41 @@ public final class RenderTextProcessor {
                 }
 
                 if (ColorCodeUtils.isFormattingCode(next)) {
-                    boolean isReset = ColorCodeUtils.isResetCode(next);
+                    char lower = Character.toLowerCase(next);
+                    if (ColorCodeUtils.isEffectCode(lower)) {
+                        instructions = ensureInstructionMap(instructions);
+                        List<RenderInstruction> bucket =
+                            instructions.computeIfAbsent(instructionIndex, key -> new ArrayList<>());
+                        switch (lower) {
+                            case 'g':
+                                bucket.add(RenderInstruction.setRainbow(true, instructionIndex));
+                                break;
+                            case 'h':
+                                bucket.add(RenderInstruction.setDinnerbone(true));
+                                break;
+                            case 'i':
+                                bucket.add(RenderInstruction.setIgnite(true));
+                                break;
+                            case 'j':
+                                bucket.add(RenderInstruction.setShake(true));
+                                break;
+                            default:
+                                break;
+                        }
+                        if (rawMode) {
+                            sanitized.append('&').append(next);
+                        } else {
+                            modified = true;
+                        }
+                        i++;
+                        continue;
+                    }
+
+                    boolean isReset = ColorCodeUtils.isResetCode(lower);
                     if (rawMode) {
                         instructions = ensureInstructionMap(instructions);
                         List<RenderInstruction> bucket =
                             instructions.computeIfAbsent(instructionIndex, key -> new ArrayList<>());
-                        char lower = Character.toLowerCase(next);
                         if (ColorCodeUtils.isMinecraftColorCode(lower)) {
                             int colorIndex = ColorCodeUtils.getMinecraftColorIndex(lower);
                             if (colorIndex >= 0) {
@@ -86,6 +117,11 @@ public final class RenderTextProcessor {
                         i++;
                         continue;
                     } else {
+                        if (isReset) {
+                            instructions = ensureInstructionMap(instructions);
+                            instructions.computeIfAbsent(instructionIndex, key -> new ArrayList<>())
+                                .add(RenderInstruction.resetToBase());
+                        }
                         sanitized.append('§');
                         modified = true;
                         continue;

--- a/src/main/java/kamkeel/hextext/client/TextEffectController.java
+++ b/src/main/java/kamkeel/hextext/client/TextEffectController.java
@@ -1,0 +1,201 @@
+package kamkeel.hextext.client;
+
+import kamkeel.hextext.config.HexTextConfig;
+import kamkeel.hextext.util.ColorCodeUtils;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import org.lwjgl.opengl.GL11;
+
+import java.util.Random;
+
+/**
+ * Maintains the state for dynamic text effects (rainbow, dinnerbone, ignite and shake).
+ */
+public final class TextEffectController {
+
+    private static final float RAINBOW_SPREAD = 12.0f;
+    private static final float SHAKE_RANGE = 1.2f;
+    private static final float IGNITE_MIN_FACTOR = 0.35f;
+
+    private final Random random = new Random();
+
+    private boolean rainbowActive;
+    private boolean dinnerboneActive;
+    private boolean igniteActive;
+    private boolean shakeActive;
+    private int rainbowAnchorIndex;
+    private long rainbowPhaseOffset;
+    private boolean rainbowPhaseInitialized;
+    private long ignitePhaseOffset;
+    private boolean ignitePhaseInitialized;
+    private int baseColor;
+    private boolean transformApplied;
+    private boolean dinnerboneCullDisabled;
+
+    public void begin(int initialColor) {
+        baseColor = initialColor;
+        rainbowActive = false;
+        dinnerboneActive = false;
+        igniteActive = false;
+        shakeActive = false;
+        transformApplied = false;
+        dinnerboneCullDisabled = false;
+    }
+
+    public void updateBaseColor(int color) {
+        baseColor = color;
+    }
+
+    public int getBaseColor() {
+        return baseColor;
+    }
+
+    public void resetDynamicEffects() {
+        rainbowActive = false;
+        dinnerboneActive = false;
+        igniteActive = false;
+        shakeActive = false;
+        rainbowAnchorIndex = 0;
+        rainbowPhaseInitialized = false;
+        ignitePhaseInitialized = false;
+        dinnerboneCullDisabled = false;
+    }
+
+    public void setRainbow(boolean enabled, int anchorIndex) {
+        if (enabled) {
+            rainbowActive = true;
+            int previousAnchor = rainbowAnchorIndex;
+            rainbowAnchorIndex = anchorIndex;
+            if (!rainbowPhaseInitialized || previousAnchor != anchorIndex) {
+                rainbowPhaseOffset = Minecraft.getSystemTime();
+                rainbowPhaseInitialized = true;
+            }
+        } else {
+            rainbowActive = false;
+            rainbowPhaseInitialized = false;
+        }
+    }
+
+    public void setDinnerbone(boolean enabled) {
+        dinnerboneActive = enabled;
+    }
+
+    public void setIgnite(boolean enabled) {
+        if (enabled) {
+            igniteActive = true;
+            if (!ignitePhaseInitialized) {
+                ignitePhaseOffset = Minecraft.getSystemTime();
+                ignitePhaseInitialized = true;
+            }
+        } else {
+            igniteActive = false;
+            ignitePhaseInitialized = false;
+        }
+    }
+
+    public void setShake(boolean enabled) {
+        shakeActive = enabled;
+    }
+
+    public boolean hasActiveEffects() {
+        return rainbowActive || dinnerboneActive || igniteActive || shakeActive;
+    }
+
+    public int computeColor(int charIndex) {
+        int color = baseColor;
+
+        if (rainbowActive && rainbowPhaseInitialized) {
+            long now = Minecraft.getSystemTime();
+            float rainbowSpeed = Math.max(1.0f, HexTextConfig.getRainbowSpeed());
+            float timeShift = (now - rainbowPhaseOffset) / rainbowSpeed;
+            float hueDegrees = (charIndex - rainbowAnchorIndex) * RAINBOW_SPREAD + timeShift * 360.0f;
+            color = ColorCodeUtils.hsvToRgb(hueDegrees, 1.0f, 1.0f);
+        }
+
+        if (igniteActive && ignitePhaseInitialized) {
+            long now = Minecraft.getSystemTime();
+            long interval = Math.max(1L, HexTextConfig.getIgniteInterval());
+            long total = Math.max(1L, interval * 2L);
+            long elapsed = now - ignitePhaseOffset;
+            float phase = (elapsed % total) / (float) total;
+            float brightness;
+            if (phase < 0.5f) {
+                float t = phase / 0.5f;
+                brightness = 1.0f - (1.0f - IGNITE_MIN_FACTOR) * t;
+            } else {
+                float t = (phase - 0.5f) / 0.5f;
+                brightness = IGNITE_MIN_FACTOR + (1.0f - IGNITE_MIN_FACTOR) * t;
+            }
+            color = applyBrightness(color, brightness);
+        }
+
+        return color;
+    }
+
+    public void beforeGlyph(FontRenderer fontRenderer, char glyph, int charIndex, float posX, float posY, int fontHeight) {
+        if (!dinnerboneActive && !shakeActive) {
+            transformApplied = false;
+            dinnerboneCullDisabled = false;
+            return;
+        }
+
+        GL11.glPushMatrix();
+        transformApplied = true;
+        dinnerboneCullDisabled = false;
+
+        if (shakeActive) {
+            applyShake(charIndex);
+        }
+
+        if (dinnerboneActive) {
+            if (GL11.glIsEnabled(GL11.GL_CULL_FACE)) {
+                GL11.glDisable(GL11.GL_CULL_FACE);
+                dinnerboneCullDisabled = true;
+            }
+            float pivotX = posX;
+            float pivotY = posY + fontHeight;
+            GL11.glTranslatef(pivotX, pivotY, 0.0f);
+            GL11.glScalef(1.0f, -1.0f, 1.0f);
+            GL11.glTranslatef(-pivotX, -pivotY, 0.0f);
+        }
+    }
+
+    public void afterGlyph() {
+        if (transformApplied) {
+            GL11.glPopMatrix();
+            if (dinnerboneCullDisabled) {
+                GL11.glEnable(GL11.GL_CULL_FACE);
+                dinnerboneCullDisabled = false;
+            }
+            transformApplied = false;
+        }
+    }
+
+    private void applyShake(int charIndex) {
+        long now = Minecraft.getSystemTime();
+        long frameWindow = Math.max(1L, HexTextConfig.getShakeInterval());
+        long seed = ((long) charIndex * 341873128712L) ^ (now / frameWindow);
+        random.setSeed(seed);
+        float offsetX = (random.nextFloat() - 0.5f) * SHAKE_RANGE;
+        float offsetY = (random.nextFloat() - 0.5f) * SHAKE_RANGE;
+        GL11.glTranslatef(offsetX, offsetY, 0.0f);
+    }
+
+    public void clearFormattingEffects() {
+        dinnerboneActive = false;
+        shakeActive = false;
+        igniteActive = false;
+        ignitePhaseInitialized = false;
+        dinnerboneCullDisabled = false;
+    }
+
+    private static int applyBrightness(int color, float factor) {
+        int r = (int) (((color >> 16) & 0xFF) * factor);
+        int g = (int) (((color >> 8) & 0xFF) * factor);
+        int b = (int) ((color & 0xFF) * factor);
+        r = Math.max(0, Math.min(255, r));
+        g = Math.max(0, Math.min(255, g));
+        b = Math.max(0, Math.min(255, b));
+        return (r << 16) | (g << 8) | b;
+    }
+}

--- a/src/main/java/kamkeel/hextext/config/HexTextConfig.java
+++ b/src/main/java/kamkeel/hextext/config/HexTextConfig.java
@@ -1,0 +1,114 @@
+package kamkeel.hextext.config;
+
+import net.minecraftforge.common.config.Configuration;
+
+import java.io.File;
+
+/**
+ * Handles loading and syncing configuration values for HexText.
+ */
+public final class HexTextConfig {
+
+    public static final String CATEGORY_EFFECTS = "effects";
+
+    private static final float DEFAULT_RAINBOW_SPEED = 55.0f;
+    private static final int DEFAULT_SHAKE_INTERVAL = 16;
+    private static final int DEFAULT_IGNITE_INTERVAL = 120;
+
+    private static final float MIN_RAINBOW_SPEED = 1.0f;
+    private static final int MIN_SHAKE_INTERVAL = 1;
+    private static final int MIN_IGNITE_INTERVAL = 1;
+
+    private static final int MAX_SHAKE_INTERVAL = 1000;
+    private static final int MAX_IGNITE_INTERVAL = 1000;
+    private static final float MAX_RAINBOW_SPEED = 5000.0f;
+
+    private static Configuration configuration;
+
+    private static float rainbowSpeed = DEFAULT_RAINBOW_SPEED;
+    private static int shakeInterval = DEFAULT_SHAKE_INTERVAL;
+    private static int igniteInterval = DEFAULT_IGNITE_INTERVAL;
+
+    private HexTextConfig() {
+    }
+
+    public static void init(File file) {
+        if (configuration == null) {
+            configuration = new Configuration(file);
+        }
+        sync();
+    }
+
+    public static void sync() {
+        if (configuration == null) {
+            return;
+        }
+
+        configuration.load();
+
+        configuration.addCustomCategoryComment(CATEGORY_EFFECTS,
+            "Timing controls for HexText's dynamic formatting effects.");
+
+        rainbowSpeed = clamp(configuration.getFloat(
+            "rainbowCycleDurationMs",
+            CATEGORY_EFFECTS,
+            DEFAULT_RAINBOW_SPEED,
+            MIN_RAINBOW_SPEED,
+            MAX_RAINBOW_SPEED,
+            "Milliseconds required for the rainbow effect to rotate through the full spectrum. Lower values move faster."
+        ), MIN_RAINBOW_SPEED, MAX_RAINBOW_SPEED);
+
+        shakeInterval = clamp(configuration.getInt(
+            "shakeUpdateIntervalMs",
+            CATEGORY_EFFECTS,
+            DEFAULT_SHAKE_INTERVAL,
+            MIN_SHAKE_INTERVAL,
+            MAX_SHAKE_INTERVAL,
+            "Milliseconds between shake offset updates. Lower values produce a more frantic shake."
+        ), MIN_SHAKE_INTERVAL, MAX_SHAKE_INTERVAL);
+
+        igniteInterval = clamp(configuration.getInt(
+            "igniteBlinkIntervalMs",
+            CATEGORY_EFFECTS,
+            DEFAULT_IGNITE_INTERVAL,
+            MIN_IGNITE_INTERVAL,
+            MAX_IGNITE_INTERVAL,
+            "Milliseconds between ignite bright and dim states. Lower values blink faster."
+        ), MIN_IGNITE_INTERVAL, MAX_IGNITE_INTERVAL);
+
+        if (configuration.hasChanged()) {
+            configuration.save();
+        }
+    }
+
+    public static float getRainbowSpeed() {
+        return rainbowSpeed;
+    }
+
+    public static int getShakeInterval() {
+        return shakeInterval;
+    }
+
+    public static int getIgniteInterval() {
+        return igniteInterval;
+    }
+
+    public static Configuration getConfiguration() {
+        return configuration;
+    }
+
+    private static float clamp(float value, float min, float max) {
+        if (value < min) {
+            return min;
+        }
+        return Math.min(value, max);
+    }
+
+    private static int clamp(int value, int min, int max) {
+        if (value < min) {
+            return min;
+        }
+        return Math.min(value, max);
+    }
+
+}

--- a/src/main/java/kamkeel/hextext/config/HexTextConfigEventHandler.java
+++ b/src/main/java/kamkeel/hextext/config/HexTextConfigEventHandler.java
@@ -1,0 +1,18 @@
+package kamkeel.hextext.config;
+
+import cpw.mods.fml.client.event.ConfigChangedEvent;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import kamkeel.hextext.HexText;
+
+/**
+ * Listens for configuration changes and resynchronizes HexText settings.
+ */
+public class HexTextConfigEventHandler {
+
+    @SubscribeEvent
+    public void onConfigChanged(ConfigChangedEvent.OnConfigChangedEvent event) {
+        if (HexText.ID.equals(event.modID)) {
+            HexTextConfig.sync();
+        }
+    }
+}

--- a/src/main/java/kamkeel/hextext/config/HexTextConfigGui.java
+++ b/src/main/java/kamkeel/hextext/config/HexTextConfigGui.java
@@ -1,0 +1,33 @@
+package kamkeel.hextext.config;
+
+import cpw.mods.fml.client.config.GuiConfig;
+import cpw.mods.fml.client.config.IConfigElement;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import kamkeel.hextext.HexText;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraftforge.common.config.ConfigElement;
+import net.minecraftforge.common.config.Configuration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@SideOnly(Side.CLIENT)
+public class HexTextConfigGui extends GuiConfig {
+
+    public HexTextConfigGui(GuiScreen parent) {
+        super(parent, getConfigElements(), HexText.ID, false, false, "HexText Configuration");
+    }
+
+    private static List<IConfigElement> getConfigElements() {
+        Configuration config = HexTextConfig.getConfiguration();
+        if (config == null) {
+            return Collections.emptyList();
+        }
+
+        List<IConfigElement> elements = new ArrayList<IConfigElement>();
+        elements.add(new ConfigElement(config.getCategory(HexTextConfig.CATEGORY_EFFECTS)));
+        return elements;
+    }
+}

--- a/src/main/java/kamkeel/hextext/config/HexTextGuiFactory.java
+++ b/src/main/java/kamkeel/hextext/config/HexTextGuiFactory.java
@@ -1,0 +1,32 @@
+package kamkeel.hextext.config;
+
+import cpw.mods.fml.client.IModGuiFactory;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
+
+import java.util.Set;
+
+@SideOnly(Side.CLIENT)
+public class HexTextGuiFactory implements IModGuiFactory {
+
+    @Override
+    public void initialize(Minecraft minecraftInstance) {
+    }
+
+    @Override
+    public Class<? extends GuiScreen> mainConfigGuiClass() {
+        return HexTextConfigGui.class;
+    }
+
+    @Override
+    public Set<RuntimeOptionCategoryElement> runtimeGuiCategories() {
+        return null;
+    }
+
+    @Override
+    public RuntimeOptionGuiHandler getHandlerFor(RuntimeOptionCategoryElement element) {
+        return null;
+    }
+}

--- a/src/main/java/kamkeel/hextext/mixins/early/impl/client/MixinFontRenderer.java
+++ b/src/main/java/kamkeel/hextext/mixins/early/impl/client/MixinFontRenderer.java
@@ -6,6 +6,7 @@ import kamkeel.hextext.client.RenderInstruction;
 import kamkeel.hextext.client.RenderTextData;
 import kamkeel.hextext.client.RenderTextProcessor;
 import kamkeel.hextext.client.TokenHighlight;
+import kamkeel.hextext.client.TextEffectController;
 import kamkeel.hextext.client.TokenHighlightUtils;
 import kamkeel.hextext.util.ColorCodeUtils;
 import kamkeel.hextext.util.StringUtils;
@@ -13,9 +14,11 @@ import net.minecraft.client.gui.FontRenderer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.gen.Invoker;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
@@ -49,10 +52,18 @@ public abstract class MixinFontRenderer {
     @Shadow(remap = false)
     protected abstract void setColor(float r, float g, float b, float a);
 
+    @Invoker("renderDefaultChar")
+    protected abstract float hextext$invokeRenderDefaultChar(int character, boolean italic);
+
+    @Invoker("renderUnicodeChar")
+    protected abstract float hextext$invokeRenderUnicodeChar(char character, boolean italic);
+
     @Unique
     private RenderTextData hextext$renderData;
     @Unique
     private Deque<Integer> hextext$colorStack;
+    @Unique
+    private Deque<Integer> hextext$baseColorStack;
     @Unique
     private int hextext$baseColor;
     @Unique
@@ -63,15 +74,24 @@ public abstract class MixinFontRenderer {
     private int hextext$rawTokenSkip;
     @Unique
     private boolean hextext$renderingShadow;
+    @Unique
+    private TextEffectController hextext$effects;
+    @Unique
+    private int hextext$currentGlyphIndex;
 
     @Inject(method = "renderStringAtPos", at = @At("HEAD"))
     private void hextext$begin(String text, boolean shadow, CallbackInfo ci) {
         boolean rawMode = FontRenderContext.isRawTextRendering();
         hextext$renderData = RenderTextProcessor.prepare(text, rawMode);
         hextext$colorStack = null;
+        hextext$baseColorStack = null;
         hextext$baseColor = this.textColor;
         hextext$shadow = shadow;
         hextext$renderingShadow = shadow;
+        if (hextext$effects == null) {
+            hextext$effects = new TextEffectController();
+        }
+        hextext$effects.begin(this.textColor);
         if (rawMode) {
             hextext$resetFormattingStyles();
         }
@@ -85,6 +105,7 @@ public abstract class MixinFontRenderer {
             hextext$pendingHighlights.clear();
         }
         hextext$rawTokenSkip = 0;
+        hextext$currentGlyphIndex = 0;
     }
 
     @ModifyVariable(method = "renderStringAtPos", at = @At("HEAD"), argsOnly = true)
@@ -116,6 +137,8 @@ public abstract class MixinFontRenderer {
             }
         }
 
+        hextext$currentGlyphIndex = index;
+
         if (hextext$renderData == null || !hextext$renderData.hasInstructions()) {
             return;
         }
@@ -134,6 +157,7 @@ public abstract class MixinFontRenderer {
     private void hextext$end(String text, boolean shadow, CallbackInfo ci) {
         hextext$renderData = null;
         hextext$colorStack = null;
+        hextext$baseColorStack = null;
         if (!hextext$renderingShadow && hextext$pendingHighlights != null && !hextext$pendingHighlights.isEmpty()) {
             TokenHighlightUtils.drawHighlights(hextext$pendingHighlights, this.FONT_HEIGHT);
             hextext$pendingHighlights.clear();
@@ -188,6 +212,37 @@ public abstract class MixinFontRenderer {
         cir.setReturnValue(StringUtils.extractFormatFromString(text));
     }
 
+    @SuppressWarnings("unused")
+    @Redirect(method = "renderCharAtPos", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;renderDefaultChar(IZ)F"))
+    private float hextext$renderDefaultChar(FontRenderer fontRenderer, int character, boolean italic,
+            int glyphIndex, char glyph, boolean italicFlag) {
+        return hextext$renderGlyphWithEffects(glyph, italic, false, character, glyph);
+    }
+
+    @SuppressWarnings("unused")
+    @Redirect(method = "renderCharAtPos", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;renderUnicodeChar(CZ)F"))
+    private float hextext$renderUnicodeChar(FontRenderer fontRenderer, char character, boolean italic,
+            int glyphIndex, char glyph, boolean italicFlag) {
+        return hextext$renderGlyphWithEffects(glyph, italic, true, 0, character);
+    }
+
+    @Unique
+    private float hextext$renderGlyphWithEffects(char glyph, boolean italic, boolean unicode, int defaultIndex, char unicodeChar) {
+        if (hextext$effects != null && hextext$effects.hasActiveEffects()) {
+            int targetColor = hextext$effects.computeColor(hextext$currentGlyphIndex);
+            hextext$applyRgbColor(targetColor, hextext$renderingShadow);
+            hextext$effects.beforeGlyph((FontRenderer) (Object) this, glyph, hextext$currentGlyphIndex, this.posX, this.posY, this.FONT_HEIGHT);
+            float width = unicode
+                ? hextext$invokeRenderUnicodeChar(unicodeChar, italic)
+                : hextext$invokeRenderDefaultChar(defaultIndex, italic);
+            hextext$effects.afterGlyph();
+            return width;
+        }
+        return unicode
+            ? hextext$invokeRenderUnicodeChar(unicodeChar, italic)
+            : hextext$invokeRenderDefaultChar(defaultIndex, italic);
+    }
+
     @Unique
     private void hextext$executeInstruction(RenderInstruction instruction) {
         switch (instruction.getType()) {
@@ -195,33 +250,72 @@ public abstract class MixinFontRenderer {
                 if (instruction.shouldClearStack() && hextext$colorStack != null) {
                     hextext$colorStack.clear();
                 }
+                if (instruction.shouldClearStack() && hextext$baseColorStack != null) {
+                    hextext$baseColorStack.clear();
+                }
                 hextext$applyRgbColor(instruction.getRgb(), hextext$shadow);
+                if (hextext$effects != null) {
+                    hextext$effects.updateBaseColor(this.textColor);
+                }
                 break;
             case APPLY_VANILLA_COLOR:
                 if (instruction.shouldClearStack() && hextext$colorStack != null) {
                     hextext$colorStack.clear();
                 }
+                if (instruction.shouldClearStack() && hextext$baseColorStack != null) {
+                    hextext$baseColorStack.clear();
+                }
                 hextext$applyVanillaColor(instruction.getParameter());
+                if (hextext$effects != null) {
+                    hextext$effects.updateBaseColor(this.textColor);
+                }
                 break;
             case PUSH_RGB:
                 if (hextext$colorStack == null) {
                     hextext$colorStack = new ArrayDeque<>();
                 }
                 hextext$colorStack.push(this.textColor);
+                if (hextext$baseColorStack == null) {
+                    hextext$baseColorStack = new ArrayDeque<>();
+                }
+                if (hextext$effects != null) {
+                    hextext$baseColorStack.push(hextext$effects.getBaseColor());
+                } else {
+                    hextext$baseColorStack.push(this.textColor);
+                }
                 hextext$applyRgbColor(instruction.getRgb(), hextext$shadow);
+                if (hextext$effects != null) {
+                    hextext$effects.updateBaseColor(this.textColor);
+                }
                 break;
             case POP_COLOR:
+                int restoredColor;
                 if (hextext$colorStack != null && !hextext$colorStack.isEmpty()) {
-                    hextext$setColorFromInt(hextext$colorStack.pop());
+                    restoredColor = hextext$colorStack.pop();
                 } else {
-                    hextext$setColorFromInt(hextext$baseColor);
+                    restoredColor = hextext$baseColor;
+                }
+                hextext$setColorFromInt(restoredColor);
+                if (hextext$effects != null) {
+                    int restoredBase = hextext$baseColor;
+                    if (hextext$baseColorStack != null && !hextext$baseColorStack.isEmpty()) {
+                        restoredBase = hextext$baseColorStack.pop();
+                    }
+                    hextext$effects.updateBaseColor(restoredBase);
                 }
                 break;
             case RESET_TO_BASE:
                 if (hextext$colorStack != null) {
                     hextext$colorStack.clear();
                 }
+                if (hextext$baseColorStack != null) {
+                    hextext$baseColorStack.clear();
+                }
                 hextext$setColorFromInt(hextext$baseColor);
+                if (hextext$effects != null) {
+                    hextext$effects.updateBaseColor(hextext$baseColor);
+                    hextext$effects.resetDynamicEffects();
+                }
                 break;
             case SET_RANDOM:
                 this.randomStyle = instruction.isEnabled();
@@ -238,10 +332,44 @@ public abstract class MixinFontRenderer {
             case SET_ITALIC:
                 this.italicStyle = instruction.isEnabled();
                 break;
+            case SET_RAINBOW:
+                if (instruction.shouldClearStack()) {
+                    if (hextext$colorStack != null) {
+                        hextext$colorStack.clear();
+                    }
+                    if (hextext$baseColorStack != null) {
+                        hextext$baseColorStack.clear();
+                    }
+                }
+                hextext$resetFormattingStyles();
+                if (hextext$effects != null) {
+                    hextext$effects.clearFormattingEffects();
+                    hextext$effects.setRainbow(instruction.isEnabled(), instruction.getParameter());
+                }
+                break;
+            case SET_DINNERBONE:
+                if (hextext$effects != null) {
+                    hextext$effects.setDinnerbone(instruction.isEnabled());
+                }
+                break;
+            case SET_IGNITE:
+                if (hextext$effects != null) {
+                    hextext$effects.setIgnite(instruction.isEnabled());
+                }
+                break;
+            case SET_SHAKE:
+                if (hextext$effects != null) {
+                    hextext$effects.setShake(instruction.isEnabled());
+                }
+                break;
         }
 
         if (instruction.resetsFormatting()) {
             hextext$resetFormattingStyles();
+            if (hextext$effects != null) {
+                hextext$effects.resetDynamicEffects();
+                hextext$effects.updateBaseColor(this.textColor);
+            }
         }
     }
 

--- a/src/main/java/kamkeel/hextext/util/ColorCodeUtils.java
+++ b/src/main/java/kamkeel/hextext/util/ColorCodeUtils.java
@@ -40,6 +40,8 @@ public final class ColorCodeUtils {
         return isMinecraftColorCode(lower)
             || lower == 'g'
             || lower == 'h'
+            || lower == 'i'
+            || lower == 'j'
             || isStyleCode(lower)
             || isResetCode(lower);
     }
@@ -63,6 +65,11 @@ public final class ColorCodeUtils {
     public static boolean isStyleCode(char c) {
         char lower = Character.toLowerCase(c);
         return lower == 'k' || lower == 'l' || lower == 'm' || lower == 'n' || lower == 'o';
+    }
+
+    public static boolean isEffectCode(char c) {
+        char lower = Character.toLowerCase(c);
+        return lower == 'g' || lower == 'h' || lower == 'i' || lower == 'j';
     }
 
     public static boolean isResetCode(char c) {

--- a/src/test/java/kamkeel/hextext/client/RenderTextProcessorTest.java
+++ b/src/test/java/kamkeel/hextext/client/RenderTextProcessorTest.java
@@ -111,4 +111,36 @@ public class RenderTextProcessorTest {
         }
         assertTrue("Expected PUSH_RGB instruction", foundPush);
     }
+
+    @Test
+    public void testRainbowInstructionNonRaw() {
+        RenderTextData data = RenderTextProcessor.prepare("&gRainbow", false);
+        assertTrue(data.shouldReplaceText());
+        assertEquals("Rainbow", data.getDisplayText());
+        assertTrue(data.hasInstructions());
+        List<RenderInstruction> instructions = data.getInstructions().get(0);
+        assertNotNull(instructions);
+        assertFalse(instructions.isEmpty());
+        RenderInstruction instruction = instructions.get(0);
+        assertEquals(RenderInstruction.Type.SET_RAINBOW, instruction.getType());
+        assertTrue(instruction.isEnabled());
+        assertEquals(0, instruction.getParameter());
+    }
+
+    @Test
+    public void testDinnerboneInstructionRaw() {
+        RenderTextData data = RenderTextProcessor.prepare("&hFlip", true);
+        assertFalse(data.shouldReplaceText());
+        assertTrue(data.hasInstructions());
+        List<RenderInstruction> instructions = data.getInstructions().get(0);
+        assertNotNull(instructions);
+        boolean found = false;
+        for (RenderInstruction instruction : instructions) {
+            if (instruction.getType() == RenderInstruction.Type.SET_DINNERBONE) {
+                assertTrue(instruction.isEnabled());
+                found = true;
+            }
+        }
+        assertTrue("Expected dinnerbone instruction", found);
+    }
 }


### PR DESCRIPTION
## Summary
- persist rainbow and ignite animation state so the colors advance over time and rainbow clears conflicting formatting when enabled
- rework ignite into a smooth dim/brighten cycle and add jitter-friendly shake seeding while keeping raw and chat renders in sync
- flip dinnerbone text with culling-safe transforms so upside-down rendering works outside raw mode

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_69014d0f4f708323984b016726646b89