### PR TITLE
Align line wrap width with vanilla logic

### DIFF
--- a/src/main/java/kamkeel/hextext/CommonProxy.java
+++ b/src/main/java/kamkeel/hextext/CommonProxy.java
@@ -1,21 +1,29 @@
 package kamkeel.hextext;
 
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import kamkeel.hextext.config.HexTextConfig;
+import kamkeel.hextext.config.HexTextConfigEventHandler;
+
 public class CommonProxy {
     public static final Logger LOGGER = LogManager.getLogger(HexText.ID);
+    private static boolean eventsRegistered;
 
     public static void eventsInit() {
-
-
+        if (!eventsRegistered) {
+            FMLCommonHandler.instance().bus().register(new HexTextConfigEventHandler());
+            eventsRegistered = true;
+        }
     }
 
     public void preInit(FMLPreInitializationEvent ev) {
+        HexTextConfig.init(ev.getSuggestedConfigurationFile());
         eventsInit();
     }
 

--- a/src/main/java/kamkeel/hextext/HexText.java
+++ b/src/main/java/kamkeel/hextext/HexText.java
@@ -14,7 +14,8 @@ import cpw.mods.fml.relauncher.Side;
 @Mod(
     modid = HexText.ID,
     name = HexText.NAME,
-    version = HexText.VERSION
+    version = HexText.VERSION,
+    guiFactory = "kamkeel.hextext.config.HexTextGuiFactory"
 )
 public class HexText {
 

--- a/src/main/java/kamkeel/hextext/client/ColorStateTracker.java
+++ b/src/main/java/kamkeel/hextext/client/ColorStateTracker.java
@@ -1,0 +1,124 @@
+package kamkeel.hextext.client;
+
+import kamkeel.hextext.util.ColorCodeUtils;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Tracks colour stack state for the font renderer so mixin logic can stay lean.
+ */
+public final class ColorStateTracker {
+
+    private final Deque<Integer> colorStack = new ArrayDeque<>();
+    private final Deque<Integer> effectBaseStack = new ArrayDeque<>();
+
+    private int baseColor;
+    private int currentColor;
+    private boolean shadowPass;
+
+    public void begin(int baseColor, boolean shadowPass) {
+        this.baseColor = baseColor & 0xFFFFFF;
+        this.currentColor = this.baseColor;
+        this.shadowPass = shadowPass;
+        colorStack.clear();
+        effectBaseStack.clear();
+    }
+
+    public int getBaseColor() {
+        return baseColor;
+    }
+
+    public int getCurrentColor() {
+        return currentColor;
+    }
+
+    public void setCurrentColor(int color) {
+        this.currentColor = color & 0xFFFFFF;
+    }
+
+    public int applyRgb(int rgb, boolean clearStacks, TextEffectController effects, boolean renderingShadow) {
+        if (clearStacks) {
+            wipeStacks();
+        }
+        int applied = convert(rgb);
+        currentColor = applied;
+        resetEffects(effects, renderingShadow, applied);
+        return applied;
+    }
+
+    public int applyVanillaColor(int colorIndex, int[] palette, boolean clearStacks, TextEffectController effects,
+            boolean renderingShadow) {
+        if (clearStacks) {
+            wipeStacks();
+        }
+        int applied = baseColor;
+        int clampedIndex = Math.max(0, Math.min(colorIndex, 15));
+        if (palette != null) {
+            int paletteIndex = shadowPass ? clampedIndex + 16 : clampedIndex;
+            if (paletteIndex >= 0 && paletteIndex < palette.length) {
+                applied = palette[paletteIndex] & 0xFFFFFF;
+            }
+        }
+        currentColor = applied;
+        resetEffects(effects, renderingShadow, applied);
+        return applied;
+    }
+
+    public int push(int rgb, TextEffectController effects, boolean renderingShadow) {
+        colorStack.push(currentColor);
+        if (effects != null) {
+            effectBaseStack.push(effects.getBaseColor());
+            effects.resetDynamicEffects();
+        }
+        int applied = convert(rgb);
+        currentColor = applied;
+        if (effects != null && !renderingShadow) {
+            effects.updateBaseColor(applied);
+        }
+        return applied;
+    }
+
+    public int pop(TextEffectController effects, boolean renderingShadow) {
+        currentColor = colorStack.isEmpty() ? baseColor : colorStack.pop();
+        if (effects != null) {
+            effects.resetDynamicEffects();
+            int base = effectBaseStack.isEmpty() ? baseColor : effectBaseStack.pop();
+            if (!renderingShadow) {
+                effects.updateBaseColor(base);
+            }
+        }
+        return currentColor;
+    }
+
+    public int resetToBase(TextEffectController effects, boolean renderingShadow) {
+        wipeStacks();
+        currentColor = baseColor;
+        resetEffects(effects, renderingShadow, baseColor);
+        return currentColor;
+    }
+
+    public void clearStacks() {
+        wipeStacks();
+    }
+
+    private int convert(int rgb) {
+        int color = rgb & 0xFFFFFF;
+        return shadowPass ? ColorCodeUtils.calculateShadowColor(color) : color;
+    }
+
+    private void wipeStacks() {
+        colorStack.clear();
+        effectBaseStack.clear();
+    }
+
+    private void resetEffects(TextEffectController effects, boolean renderingShadow, int applied) {
+        if (effects == null) {
+            return;
+        }
+        effects.resetDynamicEffects();
+        if (!renderingShadow) {
+            effects.updateBaseColor(applied);
+        }
+    }
+}

--- a/src/main/java/kamkeel/hextext/client/FormattedTextMetrics.java
+++ b/src/main/java/kamkeel/hextext/client/FormattedTextMetrics.java
@@ -33,11 +33,12 @@ public final class FormattedTextMetrics {
                         char fmt = Character.toLowerCase(text.charAt(index + 1));
                         if (fmt == 'l') {
                             isBold = true;
-                        } else if (fmt == 'r') {
-                            isBold = false;
-                        } else if ((fmt >= '0' && fmt <= '9') || (fmt >= 'a' && fmt <= 'f')) {
+                        } else if (fmt == 'r' || ColorCodeUtils.isMinecraftColorCode(fmt) || fmt == 'g') {
                             isBold = false;
                         }
+                    } else if ((codeLen == 7 && text.charAt(index) == '&')
+                        || (codeLen >= 8 && text.charAt(index) == '<')) {
+                        isBold = false;
                     }
                     index += codeLen;
                     continue;
@@ -73,8 +74,8 @@ public final class FormattedTextMetrics {
             return 0;
         }
 
-        int lastSafePosition = 0;
-        float currentWidth = 0.0f;
+        int lastSpaceIndex = -1;
+        int accumulatedWidth = 0;
         boolean isBold = false;
         final int length = text.length();
 
@@ -86,14 +87,14 @@ public final class FormattedTextMetrics {
                         char fmt = Character.toLowerCase(text.charAt(index + 1));
                         if (fmt == 'l') {
                             isBold = true;
-                        } else if (fmt == 'r') {
-                            isBold = false;
-                        } else if ((fmt >= '0' && fmt <= '9') || (fmt >= 'a' && fmt <= 'f')) {
+                        } else if (fmt == 'r' || ColorCodeUtils.isMinecraftColorCode(fmt) || fmt == 'g') {
                             isBold = false;
                         }
+                    } else if ((codeLen == 7 && text.charAt(index) == '&')
+                        || (codeLen >= 8 && text.charAt(index) == '<')) {
+                        isBold = false;
                     }
                     index += codeLen;
-                    lastSafePosition = index;
                     continue;
                 }
             }
@@ -103,27 +104,31 @@ public final class FormattedTextMetrics {
                 return index;
             }
 
-            float charWidth = charWidthFunc.getWidth(character);
-            if (charWidth < 0.0f) {
-                charWidth = 0.0f;
+            if (character == ' ') {
+                lastSpaceIndex = index;
             }
 
-            float nextWidth = currentWidth;
-            if (charWidth > 0.0f) {
-                nextWidth += charWidth;
+            int charWidth = Math.round(charWidthFunc.getWidth(character));
+            if (charWidth < 0) {
+                charWidth = 0;
+            }
+
+            if (charWidth > 0) {
+                accumulatedWidth += charWidth;
                 if (isBold) {
-                    nextWidth += boldExtra;
+                    accumulatedWidth += Math.round(boldExtra);
                 }
-                nextWidth += glyphSpacing;
+                accumulatedWidth += Math.round(glyphSpacing);
             }
 
-            if (nextWidth > maxWidth) {
-                return Math.min(lastSafePosition, length);
+            if (accumulatedWidth > maxWidth) {
+                if (lastSpaceIndex != -1 && lastSpaceIndex < index) {
+                    return lastSpaceIndex;
+                }
+                return index;
             }
 
-            currentWidth = nextWidth;
             index++;
-            lastSafePosition = index;
         }
 
         return length;

--- a/src/main/java/kamkeel/hextext/client/RenderInstruction.java
+++ b/src/main/java/kamkeel/hextext/client/RenderInstruction.java
@@ -15,7 +15,11 @@ public final class RenderInstruction {
         SET_BOLD,
         SET_STRIKETHROUGH,
         SET_UNDERLINE,
-        SET_ITALIC
+        SET_ITALIC,
+        SET_RAINBOW,
+        SET_DINNERBONE,
+        SET_IGNITE,
+        SET_SHAKE
     }
 
     private final Type type;
@@ -73,6 +77,22 @@ public final class RenderInstruction {
 
     public static RenderInstruction setItalic(boolean enabled) {
         return new RenderInstruction(Type.SET_ITALIC, 0, false, 0, enabled, false);
+    }
+
+    public static RenderInstruction setRainbow(boolean enabled, int anchorIndex) {
+        return new RenderInstruction(Type.SET_RAINBOW, 0, true, anchorIndex, enabled, true);
+    }
+
+    public static RenderInstruction setDinnerbone(boolean enabled) {
+        return new RenderInstruction(Type.SET_DINNERBONE, 0, false, 0, enabled, false);
+    }
+
+    public static RenderInstruction setIgnite(boolean enabled) {
+        return new RenderInstruction(Type.SET_IGNITE, 0, false, 0, enabled, false);
+    }
+
+    public static RenderInstruction setShake(boolean enabled) {
+        return new RenderInstruction(Type.SET_SHAKE, 0, false, 0, enabled, false);
     }
 
     public Type getType() {

--- a/src/main/java/kamkeel/hextext/client/RenderTextProcessor.java
+++ b/src/main/java/kamkeel/hextext/client/RenderTextProcessor.java
@@ -28,11 +28,14 @@ public final class RenderTextProcessor {
         for (int i = 0; i < processed.length(); i++) {
             char current = processed.charAt(i);
 
-            if (current == '&' && i + 1 < processed.length()) {
+            boolean formatIndicator = current == '&' || current == 167;
+            if (formatIndicator && i + 1 < processed.length()) {
                 char next = processed.charAt(i + 1);
+                char lower = Character.toLowerCase(next);
                 int instructionIndex = sanitized.length();
+                boolean usingSectionSign = current == 167;
 
-                if (ColorCodeUtils.isValidHexString(processed, i + 1)) {
+                if (!usingSectionSign && ColorCodeUtils.isValidHexString(processed, i + 1)) {
                     int rgb = ColorCodeUtils.parseHexColor(processed, i + 1);
                     if (rgb != -1) {
                         instructions = ensureInstructionMap(instructions);
@@ -41,55 +44,94 @@ public final class RenderTextProcessor {
                         if (rawMode) {
                             sanitized.append('&');
                             sanitized.append(processed, i + 1, i + 7);
+                        } else {
+                            modified = true;
                         }
                         i += 6;
                         continue;
                     }
                 }
 
-                if (ColorCodeUtils.isFormattingCode(next)) {
-                    boolean isReset = ColorCodeUtils.isResetCode(next);
-                    if (rawMode) {
+                if (ColorCodeUtils.isFormattingCode(lower)) {
+                    if (ColorCodeUtils.isEffectCode(lower)) {
                         instructions = ensureInstructionMap(instructions);
                         List<RenderInstruction> bucket =
                             instructions.computeIfAbsent(instructionIndex, key -> new ArrayList<>());
-                        char lower = Character.toLowerCase(next);
-                        if (ColorCodeUtils.isMinecraftColorCode(lower)) {
-                            int colorIndex = ColorCodeUtils.getMinecraftColorIndex(lower);
-                            if (colorIndex >= 0) {
-                                bucket.add(RenderInstruction.applyVanillaColor(colorIndex));
-                            }
-                        } else if (isReset) {
-                            bucket.add(RenderInstruction.resetToBase());
-                        } else if (ColorCodeUtils.isStyleCode(lower)) {
-                            switch (lower) {
-                                case 'k':
-                                    bucket.add(RenderInstruction.setRandom(true));
-                                    break;
-                                case 'l':
-                                    bucket.add(RenderInstruction.setBold(true));
-                                    break;
-                                case 'm':
-                                    bucket.add(RenderInstruction.setStrikethrough(true));
-                                    break;
-                                case 'n':
-                                    bucket.add(RenderInstruction.setUnderline(true));
-                                    break;
-                                case 'o':
-                                    bucket.add(RenderInstruction.setItalic(true));
-                                    break;
-                                default:
-                                    break;
-                            }
+                        switch (lower) {
+                            case 'g':
+                                bucket.add(RenderInstruction.setRainbow(true, instructionIndex));
+                                break;
+                            case 'h':
+                                bucket.add(RenderInstruction.setDinnerbone(true));
+                                break;
+                            case 'i':
+                                bucket.add(RenderInstruction.setIgnite(true));
+                                break;
+                            case 'j':
+                                bucket.add(RenderInstruction.setShake(true));
+                                break;
+                            default:
+                                break;
                         }
-                        sanitized.append('&').append(next);
+                        if (rawMode || usingSectionSign) {
+                            sanitized.append(current).append(next);
+                        } else {
+                            modified = true;
+                        }
                         i++;
                         continue;
+                    }
+
+                    boolean isReset = ColorCodeUtils.isResetCode(lower);
+                    boolean isColor = ColorCodeUtils.isMinecraftColorCode(lower);
+                    boolean isStyle = ColorCodeUtils.isStyleCode(lower);
+
+                    instructions = ensureInstructionMap(instructions);
+                    List<RenderInstruction> bucket =
+                        instructions.computeIfAbsent(instructionIndex, key -> new ArrayList<>());
+
+                    if (isColor) {
+                        int colorIndex = ColorCodeUtils.getMinecraftColorIndex(lower);
+                        if (colorIndex >= 0) {
+                            bucket.add(RenderInstruction.applyVanillaColor(colorIndex));
+                        }
+                    } else if (isReset) {
+                        bucket.add(RenderInstruction.resetToBase());
+                    } else if (isStyle) {
+                        switch (lower) {
+                            case 'k':
+                                bucket.add(RenderInstruction.setRandom(true));
+                                break;
+                            case 'l':
+                                bucket.add(RenderInstruction.setBold(true));
+                                break;
+                            case 'm':
+                                bucket.add(RenderInstruction.setStrikethrough(true));
+                                break;
+                            case 'n':
+                                bucket.add(RenderInstruction.setUnderline(true));
+                                break;
+                            case 'o':
+                                bucket.add(RenderInstruction.setItalic(true));
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+
+                    if (rawMode) {
+                        sanitized.append(current).append(next);
+                        i++;
+                        continue;
+                    }
+
+                    if (usingSectionSign) {
+                        sanitized.append(current);
                     } else {
                         sanitized.append('§');
                         modified = true;
-                        continue;
                     }
+                    continue;
                 }
             }
 

--- a/src/main/java/kamkeel/hextext/client/TextEffectController.java
+++ b/src/main/java/kamkeel/hextext/client/TextEffectController.java
@@ -1,0 +1,145 @@
+package kamkeel.hextext.client;
+
+import kamkeel.hextext.config.HexTextConfig;
+import kamkeel.hextext.util.ColorMath;
+import kamkeel.hextext.util.TextEffectMath;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import org.lwjgl.opengl.GL11;
+
+/**
+ * Maintains the state for dynamic text effects (rainbow, dinnerbone, ignite and shake).
+ */
+public final class TextEffectController {
+
+    private static final float RAINBOW_SPREAD = 12.0f;
+    private static final float SHAKE_VERTICAL_RANGE = 1.05f;
+    private static final long SHAKE_Y_SALT = 0xC6A4A7935BD1E995L;
+    private static final float IGNITE_MIN_FACTOR = 0.35f;
+
+    private boolean rainbowActive;
+    private boolean dinnerboneActive;
+    private boolean igniteActive;
+    private boolean shakeActive;
+    private int rainbowAnchorIndex;
+    private int baseColor;
+    private boolean transformApplied;
+    private boolean cullFaceTemporarilyDisabled;
+
+    public void begin(int initialColor) {
+        baseColor = initialColor;
+        resetDynamicEffects();
+        transformApplied = false;
+        cullFaceTemporarilyDisabled = false;
+    }
+
+    public void updateBaseColor(int color) {
+        baseColor = color;
+    }
+
+    public int getBaseColor() {
+        return baseColor;
+    }
+
+    public void resetDynamicEffects() {
+        rainbowActive = false;
+        dinnerboneActive = false;
+        igniteActive = false;
+        shakeActive = false;
+        rainbowAnchorIndex = 0;
+    }
+
+    public void setRainbow(boolean enabled, int anchorIndex) {
+        rainbowActive = enabled;
+        if (enabled) {
+            rainbowAnchorIndex = Math.max(0, anchorIndex);
+        }
+    }
+
+    public void setDinnerbone(boolean enabled) {
+        dinnerboneActive = enabled;
+    }
+
+    public void setIgnite(boolean enabled) {
+        igniteActive = enabled;
+    }
+
+    public void setShake(boolean enabled) {
+        shakeActive = enabled;
+    }
+
+    public boolean hasActiveEffects() {
+        return rainbowActive || dinnerboneActive || igniteActive || shakeActive;
+    }
+
+    public int computeColor(int charIndex) {
+        int color = baseColor;
+        long now = currentTime();
+
+        if (rainbowActive) {
+            color = TextEffectMath.computeRainbowColor(now, HexTextConfig.getRainbowSpeed(), charIndex,
+                rainbowAnchorIndex, RAINBOW_SPREAD);
+        }
+
+        if (igniteActive) {
+            float brightness = TextEffectMath.computeIgniteBrightness(now, HexTextConfig.getIgniteInterval(),
+                IGNITE_MIN_FACTOR);
+            color = ColorMath.scaleBrightness(color, brightness);
+        }
+
+        return color;
+    }
+
+    public void beforeGlyph(FontRenderer fontRenderer, char glyph, int charIndex, float posX, float posY, int fontHeight) {
+        if (!dinnerboneActive && !shakeActive) {
+            transformApplied = false;
+            return;
+        }
+
+        GL11.glPushMatrix();
+        transformApplied = true;
+        cullFaceTemporarilyDisabled = false;
+
+        if (shakeActive) {
+            applyShake(charIndex);
+        }
+
+        if (dinnerboneActive) {
+            if (GL11.glIsEnabled(GL11.GL_CULL_FACE)) {
+                GL11.glDisable(GL11.GL_CULL_FACE);
+                cullFaceTemporarilyDisabled = true;
+            }
+            float width = Math.max(1.0f, fontRenderer.getCharWidth(glyph));
+            float glyphHeight = Math.max(1.0f, fontHeight - 1.0f);
+            float pivotX = posX + width * 0.5f;
+            float pivotY = posY + glyphHeight * 0.5f;
+            float baselineOffset = Math.max(0.0f, fontHeight - glyphHeight);
+            GL11.glTranslatef(pivotX, pivotY, 0.0f);
+            GL11.glScalef(1.0f, -1.0f, 1.0f);
+            GL11.glTranslatef(-pivotX, -pivotY + baselineOffset, 0.0f);
+        }
+    }
+
+    public void afterGlyph() {
+        if (transformApplied) {
+            if (cullFaceTemporarilyDisabled) {
+                GL11.glEnable(GL11.GL_CULL_FACE);
+                cullFaceTemporarilyDisabled = false;
+            }
+            GL11.glPopMatrix();
+            transformApplied = false;
+        }
+    }
+
+    private void applyShake(int charIndex) {
+        long now = currentTime();
+        long frameWindow = Math.max(1L, HexTextConfig.getShakeInterval());
+        long seed = TextEffectMath.computeShakeSeed(charIndex, now, frameWindow);
+        float offsetY = TextEffectMath.computeShakeOffset(seed ^ SHAKE_Y_SALT, SHAKE_VERTICAL_RANGE);
+        GL11.glTranslatef(0.0f, offsetY, 0.0f);
+    }
+
+    private long currentTime() {
+        return Minecraft.getSystemTime();
+    }
+}

--- a/src/main/java/kamkeel/hextext/config/HexTextConfig.java
+++ b/src/main/java/kamkeel/hextext/config/HexTextConfig.java
@@ -1,0 +1,114 @@
+package kamkeel.hextext.config;
+
+import net.minecraftforge.common.config.Configuration;
+
+import java.io.File;
+
+/**
+ * Handles loading and syncing configuration values for HexText.
+ */
+public final class HexTextConfig {
+
+    public static final String CATEGORY_EFFECTS = "effects";
+
+    private static final float DEFAULT_RAINBOW_SPEED = 3000.0f;
+    private static final int DEFAULT_SHAKE_INTERVAL = 100;
+    private static final int DEFAULT_IGNITE_INTERVAL = 100;
+
+    private static final float MIN_RAINBOW_SPEED = 1.0f;
+    private static final int MIN_SHAKE_INTERVAL = 1;
+    private static final int MIN_IGNITE_INTERVAL = 1;
+
+    private static final int MAX_SHAKE_INTERVAL = 1000;
+    private static final int MAX_IGNITE_INTERVAL = 1000;
+    private static final float MAX_RAINBOW_SPEED = 5000.0f;
+
+    private static Configuration configuration;
+
+    private static float rainbowSpeed = DEFAULT_RAINBOW_SPEED;
+    private static int shakeInterval = DEFAULT_SHAKE_INTERVAL;
+    private static int igniteInterval = DEFAULT_IGNITE_INTERVAL;
+
+    private HexTextConfig() {
+    }
+
+    public static void init(File file) {
+        if (configuration == null) {
+            configuration = new Configuration(file);
+        }
+        sync();
+    }
+
+    public static void sync() {
+        if (configuration == null) {
+            return;
+        }
+
+        configuration.load();
+
+        configuration.addCustomCategoryComment(CATEGORY_EFFECTS,
+            "Timing controls for HexText's dynamic formatting effects.");
+
+        rainbowSpeed = clamp(configuration.getFloat(
+            "rainbowCycleDurationMs",
+            CATEGORY_EFFECTS,
+            DEFAULT_RAINBOW_SPEED,
+            MIN_RAINBOW_SPEED,
+            MAX_RAINBOW_SPEED,
+            "Milliseconds required for the rainbow effect to rotate through the full spectrum. Lower values move faster."
+        ), MIN_RAINBOW_SPEED, MAX_RAINBOW_SPEED);
+
+        shakeInterval = clamp(configuration.getInt(
+            "shakeUpdateIntervalMs",
+            CATEGORY_EFFECTS,
+            DEFAULT_SHAKE_INTERVAL,
+            MIN_SHAKE_INTERVAL,
+            MAX_SHAKE_INTERVAL,
+            "Milliseconds between shake offset updates. Lower values produce a more frantic shake."
+        ), MIN_SHAKE_INTERVAL, MAX_SHAKE_INTERVAL);
+
+        igniteInterval = clamp(configuration.getInt(
+            "igniteBlinkIntervalMs",
+            CATEGORY_EFFECTS,
+            DEFAULT_IGNITE_INTERVAL,
+            MIN_IGNITE_INTERVAL,
+            MAX_IGNITE_INTERVAL,
+            "Milliseconds for ignite to fade from bright to dim and back again. Lower values animate faster."
+        ), MIN_IGNITE_INTERVAL, MAX_IGNITE_INTERVAL);
+
+        if (configuration.hasChanged()) {
+            configuration.save();
+        }
+    }
+
+    public static float getRainbowSpeed() {
+        return rainbowSpeed;
+    }
+
+    public static int getShakeInterval() {
+        return shakeInterval;
+    }
+
+    public static int getIgniteInterval() {
+        return igniteInterval;
+    }
+
+    public static Configuration getConfiguration() {
+        return configuration;
+    }
+
+    private static float clamp(float value, float min, float max) {
+        if (value < min) {
+            return min;
+        }
+        return Math.min(value, max);
+    }
+
+    private static int clamp(int value, int min, int max) {
+        if (value < min) {
+            return min;
+        }
+        return Math.min(value, max);
+    }
+
+}

--- a/src/main/java/kamkeel/hextext/config/HexTextConfigEventHandler.java
+++ b/src/main/java/kamkeel/hextext/config/HexTextConfigEventHandler.java
@@ -1,0 +1,18 @@
+package kamkeel.hextext.config;
+
+import cpw.mods.fml.client.event.ConfigChangedEvent;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import kamkeel.hextext.HexText;
+
+/**
+ * Listens for configuration changes and resynchronizes HexText settings.
+ */
+public class HexTextConfigEventHandler {
+
+    @SubscribeEvent
+    public void onConfigChanged(ConfigChangedEvent.OnConfigChangedEvent event) {
+        if (HexText.ID.equals(event.modID)) {
+            HexTextConfig.sync();
+        }
+    }
+}

--- a/src/main/java/kamkeel/hextext/config/HexTextConfigGui.java
+++ b/src/main/java/kamkeel/hextext/config/HexTextConfigGui.java
@@ -1,0 +1,46 @@
+package kamkeel.hextext.config;
+
+import cpw.mods.fml.client.config.GuiConfig;
+import cpw.mods.fml.client.config.IConfigElement;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import kamkeel.hextext.HexText;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraftforge.common.config.ConfigElement;
+import net.minecraftforge.common.config.Configuration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@SideOnly(Side.CLIENT)
+public class HexTextConfigGui extends GuiConfig {
+
+    public HexTextConfigGui(GuiScreen parent) {
+        super(parent, getConfigElements(), HexText.ID, false, false, "HexText Configuration");
+    }
+
+    private static List<IConfigElement> getConfigElements() {
+        Configuration config = HexTextConfig.getConfiguration();
+        if (config == null) {
+            return Collections.emptyList();
+        }
+
+        List<IConfigElement> elements = new ArrayList<IConfigElement>();
+        elements.add(new ConfigElement(config.getCategory(HexTextConfig.CATEGORY_EFFECTS)));
+        return elements;
+    }
+
+    @Override
+    public void onGuiClosed() {
+        super.onGuiClosed();
+        if (this.entryList != null) {
+            this.entryList.saveConfigElements();
+        }
+        Configuration configuration = HexTextConfig.getConfiguration();
+        if (configuration != null && configuration.hasChanged()) {
+            configuration.save();
+        }
+        HexTextConfig.sync();
+    }
+}

--- a/src/main/java/kamkeel/hextext/config/HexTextGuiFactory.java
+++ b/src/main/java/kamkeel/hextext/config/HexTextGuiFactory.java
@@ -1,0 +1,32 @@
+package kamkeel.hextext.config;
+
+import cpw.mods.fml.client.IModGuiFactory;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
+
+import java.util.Set;
+
+@SideOnly(Side.CLIENT)
+public class HexTextGuiFactory implements IModGuiFactory {
+
+    @Override
+    public void initialize(Minecraft minecraftInstance) {
+    }
+
+    @Override
+    public Class<? extends GuiScreen> mainConfigGuiClass() {
+        return HexTextConfigGui.class;
+    }
+
+    @Override
+    public Set<RuntimeOptionCategoryElement> runtimeGuiCategories() {
+        return null;
+    }
+
+    @Override
+    public RuntimeOptionGuiHandler getHandlerFor(RuntimeOptionCategoryElement element) {
+        return null;
+    }
+}

--- a/src/main/java/kamkeel/hextext/mixins/early/HexTextEarlyMixins.java
+++ b/src/main/java/kamkeel/hextext/mixins/early/HexTextEarlyMixins.java
@@ -40,6 +40,7 @@ public class HexTextEarlyMixins implements IMixinConfigPlugin {
         if (side == MixinEnvironment.Side.CLIENT) {
             mixins.add("client.MixinGuiTextField");
             mixins.add("client.MixinFontRenderer");
+            mixins.add("client.MixinGuiNewChat");
         }
         return mixins;
     }

--- a/src/main/java/kamkeel/hextext/mixins/early/impl/client/MixinFontRenderer.java
+++ b/src/main/java/kamkeel/hextext/mixins/early/impl/client/MixinFontRenderer.java
@@ -1,11 +1,13 @@
 package kamkeel.hextext.mixins.early.impl.client;
 
+import kamkeel.hextext.client.ColorStateTracker;
 import kamkeel.hextext.client.FontRenderContext;
 import kamkeel.hextext.client.FontRendererUtils;
 import kamkeel.hextext.client.RenderInstruction;
 import kamkeel.hextext.client.RenderTextData;
 import kamkeel.hextext.client.RenderTextProcessor;
 import kamkeel.hextext.client.TokenHighlight;
+import kamkeel.hextext.client.TextEffectController;
 import kamkeel.hextext.client.TokenHighlightUtils;
 import kamkeel.hextext.util.ColorCodeUtils;
 import kamkeel.hextext.util.StringUtils;
@@ -13,16 +15,16 @@ import net.minecraft.client.gui.FontRenderer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.gen.Invoker;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Deque;
 import java.util.List;
 
 @Mixin(value = FontRenderer.class)
@@ -49,12 +51,16 @@ public abstract class MixinFontRenderer {
     @Shadow(remap = false)
     protected abstract void setColor(float r, float g, float b, float a);
 
+    @Invoker("renderDefaultChar")
+    protected abstract float hextext$invokeRenderDefaultChar(int character, boolean italic);
+
+    @Invoker("renderUnicodeChar")
+    protected abstract float hextext$invokeRenderUnicodeChar(char character, boolean italic);
+
     @Unique
     private RenderTextData hextext$renderData;
     @Unique
-    private Deque<Integer> hextext$colorStack;
-    @Unique
-    private int hextext$baseColor;
+    private ColorStateTracker hextext$colorState;
     @Unique
     private boolean hextext$shadow;
     @Unique
@@ -63,15 +69,38 @@ public abstract class MixinFontRenderer {
     private int hextext$rawTokenSkip;
     @Unique
     private boolean hextext$renderingShadow;
+    @Unique
+    private TextEffectController hextext$effects;
+    @Unique
+    private int hextext$visibleGlyphIndex;
+    @Unique
+    private int hextext$pendingRenderColor;
+    @Unique
+    private boolean hextext$hasPendingRenderColor;
+
+    @Inject(method = "renderString", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;setColor(FFFF)V", shift = At.Shift.AFTER, remap = false), locals = LocalCapture.CAPTURE_FAILHARD)
+    private void hextext$capturePreparedColor(String text, int x, int y, int color, boolean dropShadow,
+            CallbackInfoReturnable<Integer> cir) {
+        hextext$pendingRenderColor = color & 0xFFFFFF;
+        hextext$hasPendingRenderColor = true;
+    }
 
     @Inject(method = "renderStringAtPos", at = @At("HEAD"))
     private void hextext$begin(String text, boolean shadow, CallbackInfo ci) {
         boolean rawMode = FontRenderContext.isRawTextRendering();
         hextext$renderData = RenderTextProcessor.prepare(text, rawMode);
-        hextext$colorStack = null;
-        hextext$baseColor = this.textColor;
+        if (hextext$colorState == null) {
+            hextext$colorState = new ColorStateTracker();
+        }
         hextext$shadow = shadow;
         hextext$renderingShadow = shadow;
+        if (hextext$effects == null) {
+            hextext$effects = new TextEffectController();
+        }
+        int initialColor = hextext$resolveInitialColor();
+        hextext$colorState.begin(initialColor, shadow);
+        this.textColor = initialColor;
+        hextext$effects.begin(initialColor);
         if (rawMode) {
             hextext$resetFormattingStyles();
         }
@@ -85,6 +114,7 @@ public abstract class MixinFontRenderer {
             hextext$pendingHighlights.clear();
         }
         hextext$rawTokenSkip = 0;
+        hextext$visibleGlyphIndex = 0;
     }
 
     @ModifyVariable(method = "renderStringAtPos", at = @At("HEAD"), argsOnly = true)
@@ -133,7 +163,6 @@ public abstract class MixinFontRenderer {
     @Inject(method = "renderStringAtPos", at = @At("TAIL"))
     private void hextext$end(String text, boolean shadow, CallbackInfo ci) {
         hextext$renderData = null;
-        hextext$colorStack = null;
         if (!hextext$renderingShadow && hextext$pendingHighlights != null && !hextext$pendingHighlights.isEmpty()) {
             TokenHighlightUtils.drawHighlights(hextext$pendingHighlights, this.FONT_HEIGHT);
             hextext$pendingHighlights.clear();
@@ -188,40 +217,72 @@ public abstract class MixinFontRenderer {
         cir.setReturnValue(StringUtils.extractFormatFromString(text));
     }
 
+    @SuppressWarnings("unused")
+    @Redirect(method = "renderCharAtPos", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;renderDefaultChar(IZ)F"))
+    private float hextext$renderDefaultChar(FontRenderer fontRenderer, int character, boolean italic,
+            int glyphIndex, char glyph, boolean italicFlag) {
+        return hextext$renderGlyphWithEffects(glyph, italic, false, character, glyph);
+    }
+
+    @SuppressWarnings("unused")
+    @Redirect(method = "renderCharAtPos", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;renderUnicodeChar(CZ)F"))
+    private float hextext$renderUnicodeChar(FontRenderer fontRenderer, char character, boolean italic,
+            int glyphIndex, char glyph, boolean italicFlag) {
+        return hextext$renderGlyphWithEffects(glyph, italic, true, 0, character);
+    }
+
+    @Unique
+    private float hextext$renderGlyphWithEffects(char glyph, boolean italic, boolean unicode, int defaultIndex, char unicodeChar) {
+        int glyphIndex = hextext$visibleGlyphIndex;
+        float width;
+        if (hextext$effects != null && hextext$effects.hasActiveEffects()) {
+            int targetColor = hextext$effects.computeColor(glyphIndex);
+            int appliedColor = hextext$shadow ? ColorCodeUtils.calculateShadowColor(targetColor) : targetColor;
+            hextext$setColorFromInt(appliedColor);
+            hextext$effects.beforeGlyph((FontRenderer) (Object) this, glyph, glyphIndex, this.posX, this.posY, this.FONT_HEIGHT);
+            width = unicode
+                ? hextext$invokeRenderUnicodeChar(unicodeChar, italic)
+                : hextext$invokeRenderDefaultChar(defaultIndex, italic);
+            hextext$effects.afterGlyph();
+        } else {
+            width = unicode
+                ? hextext$invokeRenderUnicodeChar(unicodeChar, italic)
+                : hextext$invokeRenderDefaultChar(defaultIndex, italic);
+        }
+        return width;
+    }
+
+    @Inject(method = "doDraw", at = @At("TAIL"), remap = false)
+    private void hextext$advanceVisibleGlyphIndex(float width, CallbackInfo ci) {
+        hextext$visibleGlyphIndex++;
+    }
+
     @Unique
     private void hextext$executeInstruction(RenderInstruction instruction) {
+        boolean resetStyles = instruction.resetsFormatting();
+
         switch (instruction.getType()) {
             case APPLY_RGB:
-                if (instruction.shouldClearStack() && hextext$colorStack != null) {
-                    hextext$colorStack.clear();
-                }
-                hextext$applyRgbColor(instruction.getRgb(), hextext$shadow);
+                int appliedRgb = hextext$colorState.applyRgb(instruction.getRgb(), instruction.shouldClearStack(),
+                    hextext$effects, hextext$renderingShadow);
+                hextext$setColorFromInt(appliedRgb);
                 break;
             case APPLY_VANILLA_COLOR:
-                if (instruction.shouldClearStack() && hextext$colorStack != null) {
-                    hextext$colorStack.clear();
-                }
-                hextext$applyVanillaColor(instruction.getParameter());
+                int vanillaColor = hextext$colorState.applyVanillaColor(instruction.getParameter(), colorCode,
+                    instruction.shouldClearStack(), hextext$effects, hextext$renderingShadow);
+                hextext$setColorFromInt(vanillaColor);
                 break;
             case PUSH_RGB:
-                if (hextext$colorStack == null) {
-                    hextext$colorStack = new ArrayDeque<>();
-                }
-                hextext$colorStack.push(this.textColor);
-                hextext$applyRgbColor(instruction.getRgb(), hextext$shadow);
+                int pushedColor = hextext$colorState.push(instruction.getRgb(), hextext$effects, hextext$renderingShadow);
+                hextext$setColorFromInt(pushedColor);
                 break;
             case POP_COLOR:
-                if (hextext$colorStack != null && !hextext$colorStack.isEmpty()) {
-                    hextext$setColorFromInt(hextext$colorStack.pop());
-                } else {
-                    hextext$setColorFromInt(hextext$baseColor);
-                }
+                int restoredColor = hextext$colorState.pop(hextext$effects, hextext$renderingShadow);
+                hextext$setColorFromInt(restoredColor);
                 break;
             case RESET_TO_BASE:
-                if (hextext$colorStack != null) {
-                    hextext$colorStack.clear();
-                }
-                hextext$setColorFromInt(hextext$baseColor);
+                int baseColor = hextext$colorState.resetToBase(hextext$effects, hextext$renderingShadow);
+                hextext$setColorFromInt(baseColor);
                 break;
             case SET_RANDOM:
                 this.randomStyle = instruction.isEnabled();
@@ -238,16 +299,51 @@ public abstract class MixinFontRenderer {
             case SET_ITALIC:
                 this.italicStyle = instruction.isEnabled();
                 break;
+            case SET_RAINBOW:
+                if (instruction.shouldClearStack()) {
+                    hextext$colorState.clearStacks();
+                }
+                if (hextext$effects != null) {
+                    hextext$effects.resetDynamicEffects();
+                    hextext$effects.setRainbow(instruction.isEnabled(), hextext$visibleGlyphIndex);
+                    if (!hextext$renderingShadow) {
+                        hextext$effects.updateBaseColor(this.textColor);
+                    }
+                }
+                resetStyles = true;
+                break;
+            case SET_DINNERBONE:
+                if (hextext$effects != null) {
+                    hextext$effects.setDinnerbone(instruction.isEnabled());
+                }
+                break;
+            case SET_IGNITE:
+                if (hextext$effects != null) {
+                    if (instruction.isEnabled() && !hextext$renderingShadow) {
+                        hextext$effects.updateBaseColor(this.textColor);
+                    }
+                    hextext$effects.setIgnite(instruction.isEnabled());
+                }
+                break;
+            case SET_SHAKE:
+                if (hextext$effects != null) {
+                    hextext$effects.setShake(instruction.isEnabled());
+                }
+                break;
         }
 
-        if (instruction.resetsFormatting()) {
+        if (resetStyles) {
             hextext$resetFormattingStyles();
         }
     }
 
     @Unique
     private void hextext$setColorFromInt(int rgb) {
-        this.textColor = rgb;
+        int masked = rgb & 0xFFFFFF;
+        this.textColor = masked;
+        if (hextext$colorState != null) {
+            hextext$colorState.setCurrentColor(masked);
+        }
         setColor((float) (rgb >> 16 & 255) / 255.0F,
             (float) (rgb >> 8 & 255) / 255.0F,
             (float) (rgb & 255) / 255.0F,
@@ -255,20 +351,15 @@ public abstract class MixinFontRenderer {
     }
 
     @Unique
-    private void hextext$applyRgbColor(int rgb, boolean shadow) {
-        int effective = shadow ? ColorCodeUtils.calculateShadowColor(rgb) : rgb;
-        hextext$setColorFromInt(effective);
-    }
-
-    @Unique
-    private void hextext$applyVanillaColor(int colorIndex) {
-        int index = Math.max(0, Math.min(colorIndex, 15));
-        int paletteIndex = hextext$shadow ? index + 16 : index;
-        if (colorCode != null && paletteIndex >= 0 && paletteIndex < colorCode.length) {
-            hextext$setColorFromInt(colorCode[paletteIndex]);
-        } else {
-            hextext$setColorFromInt(hextext$baseColor);
+    private int hextext$resolveInitialColor() {
+        if (hextext$hasPendingRenderColor) {
+            hextext$hasPendingRenderColor = false;
+            return hextext$pendingRenderColor & 0xFFFFFF;
         }
+        int r = Math.round(this.red * 255.0f);
+        int g = Math.round(this.blue * 255.0f);
+        int b = Math.round(this.green * 255.0f);
+        return (r << 16) | (g << 8) | b;
     }
 
     @Unique

--- a/src/main/java/kamkeel/hextext/mixins/early/impl/client/MixinGuiNewChat.java
+++ b/src/main/java/kamkeel/hextext/mixins/early/impl/client/MixinGuiNewChat.java
@@ -1,0 +1,35 @@
+package kamkeel.hextext.mixins.early.impl.client;
+
+import kamkeel.hextext.util.StringUtils;
+import net.minecraft.client.gui.GuiNewChat;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+@Mixin(GuiNewChat.class)
+public abstract class MixinGuiNewChat {
+
+    @Unique
+    private String hextext$wrappedFormatPrefix = "";
+
+    @ModifyVariable(method = "func_146237_a",
+        at = @At(value = "STORE"),
+        name = "s1")
+    private String hextext$captureWrappedPrefix(String value) {
+        hextext$wrappedFormatPrefix = StringUtils.extractFormatFromString(value);
+        return value;
+    }
+
+    @ModifyArgs(method = "func_146237_a",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/util/ChatComponentText;<init>(Ljava/lang/String;)V", ordinal = 2))
+    private void hextext$prependFormatCodes(Args args) {
+        if (!hextext$wrappedFormatPrefix.isEmpty()) {
+            String value = args.get(0);
+            args.set(0, hextext$wrappedFormatPrefix + value);
+        }
+        hextext$wrappedFormatPrefix = "";
+    }
+}

--- a/src/main/java/kamkeel/hextext/util/ColorCodeUtils.java
+++ b/src/main/java/kamkeel/hextext/util/ColorCodeUtils.java
@@ -40,6 +40,8 @@ public final class ColorCodeUtils {
         return isMinecraftColorCode(lower)
             || lower == 'g'
             || lower == 'h'
+            || lower == 'i'
+            || lower == 'j'
             || isStyleCode(lower)
             || isResetCode(lower);
     }
@@ -63,6 +65,11 @@ public final class ColorCodeUtils {
     public static boolean isStyleCode(char c) {
         char lower = Character.toLowerCase(c);
         return lower == 'k' || lower == 'l' || lower == 'm' || lower == 'n' || lower == 'o';
+    }
+
+    public static boolean isEffectCode(char c) {
+        char lower = Character.toLowerCase(c);
+        return lower == 'g' || lower == 'h' || lower == 'i' || lower == 'j';
     }
 
     public static boolean isResetCode(char c) {

--- a/src/main/java/kamkeel/hextext/util/ColorMath.java
+++ b/src/main/java/kamkeel/hextext/util/ColorMath.java
@@ -1,0 +1,50 @@
+package kamkeel.hextext.util;
+
+/**
+ * Simple colour math helpers shared by the text effect controller and tests.
+ */
+public final class ColorMath {
+
+    private ColorMath() {
+    }
+
+    public static int scaleBrightness(int color, float factor) {
+        float clampedFactor = clamp(factor, 0.0f, 8.0f);
+        int red = clampChannel(((color >> 16) & 0xFF) * clampedFactor);
+        int green = clampChannel(((color >> 8) & 0xFF) * clampedFactor);
+        int blue = clampChannel((color & 0xFF) * clampedFactor);
+        return (red << 16) | (green << 8) | blue;
+    }
+
+    public static int blend(int first, int second, float ratio) {
+        float clampedRatio = clamp(ratio, 0.0f, 1.0f);
+        float inverse = 1.0f - clampedRatio;
+
+        int red = clampChannel(((first >> 16) & 0xFF) * inverse + ((second >> 16) & 0xFF) * clampedRatio);
+        int green = clampChannel(((first >> 8) & 0xFF) * inverse + ((second >> 8) & 0xFF) * clampedRatio);
+        int blue = clampChannel((first & 0xFF) * inverse + (second & 0xFF) * clampedRatio);
+
+        return (red << 16) | (green << 8) | blue;
+    }
+
+    private static int clampChannel(float value) {
+        int rounded = Math.round(value);
+        if (rounded < 0) {
+            return 0;
+        }
+        if (rounded > 255) {
+            return 255;
+        }
+        return rounded;
+    }
+
+    private static float clamp(float value, float min, float max) {
+        if (value < min) {
+            return min;
+        }
+        if (value > max) {
+            return max;
+        }
+        return value;
+    }
+}

--- a/src/main/java/kamkeel/hextext/util/StringUtils.java
+++ b/src/main/java/kamkeel/hextext/util/StringUtils.java
@@ -48,7 +48,7 @@ public final class StringUtils {
         }
 
         String currentColorCode = null;
-        StringBuilder styleCodes = new StringBuilder();
+        StringBuilder formatCodes = new StringBuilder();
         ArrayDeque<String> colorStack = new ArrayDeque<>();
 
         for (int i = 0; i < str.length(); ) {
@@ -61,29 +61,29 @@ public final class StringUtils {
                 if (codeLen == 7 && firstChar == '&') {
                     currentColorCode = code;
                     colorStack.clear();
-                    styleCodes.setLength(0);
+                    formatCodes.setLength(0);
                 } else if (codeLen == 8 && firstChar == '<') {
                     if (currentColorCode != null) {
                         colorStack.push(currentColorCode);
                     }
                     currentColorCode = code;
-                    styleCodes.setLength(0);
+                    formatCodes.setLength(0);
                 } else if (codeLen == 9 && firstChar == '<') {
                     currentColorCode = colorStack.isEmpty() ? null : colorStack.pop();
-                    styleCodes.setLength(0);
+                    formatCodes.setLength(0);
                 } else if (codeLen == 2) {
                     char fmt = Character.toLowerCase(str.charAt(i + 1));
 
-                    if (ColorCodeUtils.isMinecraftColorCode(fmt)) {
+                    if (ColorCodeUtils.isMinecraftColorCode(fmt) || fmt == 'g') {
                         currentColorCode = code;
                         colorStack.clear();
-                        styleCodes.setLength(0);
+                        formatCodes.setLength(0);
                     } else if (ColorCodeUtils.isResetCode(fmt)) {
                         currentColorCode = null;
                         colorStack.clear();
-                        styleCodes.setLength(0);
-                    } else if (ColorCodeUtils.isStyleCode(fmt)) {
-                        styleCodes.append(code);
+                        formatCodes.setLength(0);
+                    } else if (ColorCodeUtils.isStyleCode(fmt) || (ColorCodeUtils.isEffectCode(fmt) && fmt != 'g')) {
+                        formatCodes.append(code);
                     }
                 }
 
@@ -98,8 +98,8 @@ public final class StringUtils {
         if (currentColorCode != null) {
             result.append(currentColorCode);
         }
-        if (styleCodes.length() > 0) {
-            result.append(styleCodes);
+        if (formatCodes.length() > 0) {
+            result.append(formatCodes);
         }
 
         return result.toString();

--- a/src/main/java/kamkeel/hextext/util/TextEffectMath.java
+++ b/src/main/java/kamkeel/hextext/util/TextEffectMath.java
@@ -1,0 +1,64 @@
+package kamkeel.hextext.util;
+
+/**
+ * Deterministic helpers for dynamic text effect calculations.
+ */
+public final class TextEffectMath {
+
+    private static final float RAINBOW_SATURATION = 0.9f;
+    private static final float RAINBOW_LIGHTEN_RATIO = 0.18f;
+
+    private TextEffectMath() {
+    }
+
+    public static int computeRainbowColor(long now, double rainbowSpeed, int charIndex, int anchorIndex, float spread) {
+        double safeSpeed = rainbowSpeed < 1.0 ? 1.0 : rainbowSpeed;
+        double timeDegrees = (now / safeSpeed) * 360.0;
+        float hueDegrees = (float) ((charIndex - anchorIndex) * spread + timeDegrees);
+        int base = ColorCodeUtils.hsvToRgb(hueDegrees, RAINBOW_SATURATION, 1.0f);
+        return ColorMath.blend(base, 0xFFFFFF, RAINBOW_LIGHTEN_RATIO);
+    }
+
+    public static float computeIgniteBrightness(long now, long interval, float minimumFactor) {
+        long safeInterval = interval <= 0 ? 1L : interval;
+        long period = safeInterval * 2L;
+        long phase = now % period;
+        if (phase < 0) {
+            phase += period;
+        }
+
+        float progress;
+        if (phase <= safeInterval) {
+            progress = 1.0f - (float) phase / (float) safeInterval;
+        } else {
+            progress = (float) (phase - safeInterval) / (float) safeInterval;
+        }
+
+        float minClamp = minimumFactor < 0.0f ? 0.0f : (minimumFactor > 1.0f ? 1.0f : minimumFactor);
+        return minClamp + (1.0f - minClamp) * progress;
+    }
+
+    public static long computeShakeSeed(int charIndex, long now, long frameWindow) {
+        long safeFrame = frameWindow <= 0 ? 1L : frameWindow;
+        return ((long) charIndex * 341873128712L) ^ (now / safeFrame);
+    }
+
+    public static float computeShakeOffset(long seed, float range) {
+        float safeRange = range < 0.0f ? 0.0f : range;
+        if (safeRange == 0.0f) {
+            return 0.0f;
+        }
+        long mixed = mix(seed);
+        float normalized = ((mixed >>> 40) & 0xFFFFFF) / (float) 0xFFFFFF;
+        return (normalized * 2.0f - 1.0f) * safeRange;
+    }
+
+    private static long mix(long value) {
+        value ^= value >>> 33;
+        value *= 0xff51afd7ed558ccdL;
+        value ^= value >>> 33;
+        value *= 0xc4ceb9fe1a85ec53L;
+        value ^= value >>> 33;
+        return value;
+    }
+}

--- a/src/test/java/kamkeel/hextext/client/ColorStateTrackerTest.java
+++ b/src/test/java/kamkeel/hextext/client/ColorStateTrackerTest.java
@@ -1,0 +1,61 @@
+package kamkeel.hextext.client;
+
+import kamkeel.hextext.util.ColorCodeUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ColorStateTrackerTest {
+
+    @Test
+    public void testResetToBaseRestoresInitialColour() {
+        ColorStateTracker tracker = new ColorStateTracker();
+        tracker.begin(0xFFFFFF, false);
+        tracker.applyRgb(0xFF0000, false, null, false);
+        assertEquals(0xFF0000, tracker.getCurrentColor());
+        int restored = tracker.resetToBase(null, false);
+        assertEquals(0xFFFFFF, restored);
+        assertEquals(0xFFFFFF, tracker.getCurrentColor());
+    }
+
+    @Test
+    public void testPushAndPopRoundTrip() {
+        ColorStateTracker tracker = new ColorStateTracker();
+        tracker.begin(0xFFFFFF, false);
+        tracker.applyRgb(0x00FF00, false, null, false);
+        tracker.push(0x0000FF, null, false);
+        assertEquals(0x0000FF, tracker.getCurrentColor());
+        int popped = tracker.pop(null, false);
+        assertEquals(0x00FF00, popped);
+        assertEquals(0x00FF00, tracker.getCurrentColor());
+    }
+
+    @Test
+    public void testApplyRgbClearsStackWhenRequested() {
+        ColorStateTracker tracker = new ColorStateTracker();
+        tracker.begin(0xFFFFFF, false);
+        tracker.push(0xFF0000, null, false);
+        tracker.applyRgb(0x00FF00, true, null, false);
+        int popped = tracker.pop(null, false);
+        assertEquals(0xFFFFFF, popped);
+    }
+
+    @Test
+    public void testVanillaColorUsesPalette() {
+        ColorStateTracker tracker = new ColorStateTracker();
+        tracker.begin(0xFFFFFF, false);
+        int[] palette = new int[32];
+        palette[5] = 0x123456;
+        int applied = tracker.applyVanillaColor(5, palette, false, null, false);
+        assertEquals(0x123456, applied);
+    }
+
+    @Test
+    public void testShadowRgbConversion() {
+        ColorStateTracker tracker = new ColorStateTracker();
+        tracker.begin(0xFFFFFF, true);
+        int rgb = 0x336699;
+        int applied = tracker.applyRgb(rgb, false, null, true);
+        assertEquals(ColorCodeUtils.calculateShadowColor(rgb), applied);
+    }
+}

--- a/src/test/java/kamkeel/hextext/client/FormattedTextMetricsTest.java
+++ b/src/test/java/kamkeel/hextext/client/FormattedTextMetricsTest.java
@@ -1,0 +1,169 @@
+package kamkeel.hextext.client;
+
+import kamkeel.hextext.client.support.SimpleCharWidthFunction;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class FormattedTextMetricsTest {
+
+    @Test
+    public void calculateMaxLineWidthSkipsFormattingCodes() {
+        SimpleCharWidthFunction widthFunction = new SimpleCharWidthFunction(5.0f);
+        float width = FormattedTextMetrics.calculateMaxLineWidth("&aAB", false, widthFunction, 0.0f, 1.0f);
+        assertEquals(10.0f, width, 0.0001f);
+    }
+
+    @Test
+    public void calculateMaxLineWidthAccountsForBold() {
+        SimpleCharWidthFunction widthFunction = new SimpleCharWidthFunction(5.0f);
+        float width = FormattedTextMetrics.calculateMaxLineWidth("&lAB&rC", false, widthFunction, 0.0f, 1.0f);
+        assertEquals(17.0f, width, 0.0001f);
+    }
+
+    @Test
+    public void computeLineBreakHonoursSafePositions() {
+        SimpleCharWidthFunction widthFunction = new SimpleCharWidthFunction(5.0f);
+        widthFunction.setWidth(' ', 2.0f);
+        int breakIndex = FormattedTextMetrics.computeLineBreakIndex("AB CD", 12, false, widthFunction, 0.0f, 1.0f);
+        assertEquals(2, breakIndex);
+    }
+
+    @Test
+    public void formattingCodesDoNotIncreaseWidth() {
+        SimpleCharWidthFunction widthFunction = new SimpleCharWidthFunction(5.0f);
+        float width = FormattedTextMetrics.calculateMaxLineWidth("&hFlip&i&j", false, widthFunction, 0.0f, 1.0f);
+        assertEquals(20.0f, width, 0.0001f);
+    }
+
+    @Test
+    public void rainbowCodeResetsBoldWidth() {
+        SimpleCharWidthFunction widthFunction = new SimpleCharWidthFunction(5.0f);
+        float width = FormattedTextMetrics.calculateMaxLineWidth("&lA&gBC", false, widthFunction, 0.0f, 1.0f);
+        assertEquals(16.0f, width, 0.0001f);
+    }
+
+    @Test
+    public void rgbPushResetsBoldWidth() {
+        SimpleCharWidthFunction widthFunction = new SimpleCharWidthFunction(5.0f);
+        float width = FormattedTextMetrics.calculateMaxLineWidth("&lA<123456>BC", false, widthFunction, 0.0f, 1.0f);
+        assertEquals(16.0f, width, 0.0001f);
+    }
+
+    @Test
+    public void computeLineBreakMatchesVanillaWithBold() {
+        SimpleCharWidthFunction widthFunction = new SimpleCharWidthFunction(5.0f);
+        widthFunction.setWidth(' ', 4.0f);
+        String text = "\u00A7lHello world";
+        int maxWidth = 30;
+
+        int expected = vanillaSizeStringToWidth(text, maxWidth, widthFunction);
+        int actual = FormattedTextMetrics.computeLineBreakIndex(text, maxWidth, false, widthFunction, 0.0f, 1.0f);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void computeLineBreakMatchesVanillaWhenBoldResets() {
+        SimpleCharWidthFunction widthFunction = new SimpleCharWidthFunction(5.0f);
+        widthFunction.setWidth(' ', 4.0f);
+        String text = "\u00A7lHello \u00A7cworld";
+        int maxWidth = 34;
+
+        int expected = vanillaSizeStringToWidth(text, maxWidth, widthFunction);
+        int actual = FormattedTextMetrics.computeLineBreakIndex(text, maxWidth, false, widthFunction, 0.0f, 1.0f);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void computeLineBreakMatchesVanillaForRandomisedInputs() {
+        SimpleCharWidthFunction widthFunction = new SimpleCharWidthFunction(4.0f);
+        widthFunction.setWidth(' ', 3.0f);
+        widthFunction.setWidth('A', 6.0f);
+        widthFunction.setWidth('B', 5.0f);
+        widthFunction.setWidth('C', 7.0f);
+
+        java.util.Random random = new java.util.Random(0xCAFE);
+        char[] letters = new char[] {'A', 'B', 'C', ' '};
+        char[] formatCodes = new char[] {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            'a', 'b', 'c', 'd', 'e', 'f', 'k', 'l', 'm', 'n', 'o', 'r'};
+
+        for (int iteration = 0; iteration < 5_000; iteration++) {
+            StringBuilder builder = new StringBuilder();
+            int length = 5 + random.nextInt(20);
+
+            for (int i = 0; i < length; i++) {
+                int choice = random.nextInt(10);
+                if (choice == 0) {
+                    builder.append('\u00A7');
+                    builder.append(formatCodes[random.nextInt(formatCodes.length)]);
+                } else if (choice == 1) {
+                    builder.append('\n');
+                } else {
+                    builder.append(letters[random.nextInt(letters.length)]);
+                }
+            }
+
+            String text = builder.toString();
+            int maxWidth = 5 + random.nextInt(40);
+
+            int expected = vanillaSizeStringToWidth(text, maxWidth, widthFunction);
+            int actual = FormattedTextMetrics.computeLineBreakIndex(text, maxWidth, false,
+                widthFunction, 0.0f, 1.0f);
+
+            assertEquals("Mismatch for text=" + text + " width=" + maxWidth, expected, actual);
+        }
+    }
+
+    private static int vanillaSizeStringToWidth(CharSequence text, int maxWidth,
+            SimpleCharWidthFunction widthFunction) {
+        int length = text.length();
+        int width = 0;
+        int index = 0;
+        int lastSpace = -1;
+        boolean bold = false;
+
+        while (index < length) {
+            char character = text.charAt(index);
+
+            if (character == '\n') {
+                lastSpace = index;
+                break;
+            }
+
+            if (character == '\u00A7' && index + 1 < length) {
+                char format = Character.toLowerCase(text.charAt(++index));
+                if (format == 'l') {
+                    bold = true;
+                } else if (format == 'r' || (format >= '0' && format <= '9') || (format >= 'a' && format <= 'f')) {
+                    bold = false;
+                }
+                index++;
+                continue;
+            }
+
+            if (character == ' ') {
+                lastSpace = index;
+            }
+
+            int charWidth = Math.max(0, Math.round(widthFunction.getWidth(character)));
+            width += charWidth;
+            if (bold && charWidth > 0) {
+                width += 1;
+            }
+
+            if (width > maxWidth) {
+                break;
+            }
+
+            index++;
+        }
+
+        if (index != length && lastSpace != -1 && lastSpace < index) {
+            return lastSpace;
+        }
+
+        return index;
+    }
+}

--- a/src/test/java/kamkeel/hextext/client/RenderTextProcessorTest.java
+++ b/src/test/java/kamkeel/hextext/client/RenderTextProcessorTest.java
@@ -111,4 +111,99 @@ public class RenderTextProcessorTest {
         }
         assertTrue("Expected PUSH_RGB instruction", foundPush);
     }
+
+    @Test
+    public void testRainbowInstructionNonRaw() {
+        RenderTextData data = RenderTextProcessor.prepare("&gRainbow", false);
+        assertTrue(data.shouldReplaceText());
+        assertEquals("Rainbow", data.getDisplayText());
+        assertTrue(data.hasInstructions());
+        List<RenderInstruction> instructions = data.getInstructions().get(0);
+        assertNotNull(instructions);
+        assertFalse(instructions.isEmpty());
+        RenderInstruction instruction = instructions.get(0);
+        assertEquals(RenderInstruction.Type.SET_RAINBOW, instruction.getType());
+        assertTrue(instruction.isEnabled());
+        assertEquals(0, instruction.getParameter());
+        assertTrue(instruction.resetsFormatting());
+    }
+
+    @Test
+    public void testNonRawVanillaColorProducesInstruction() {
+        RenderTextData data = RenderTextProcessor.prepare("&aGreen", false);
+        assertTrue(data.shouldReplaceText());
+        assertEquals("§aGreen", data.getDisplayText());
+        assertTrue(data.hasInstructions());
+        List<RenderInstruction> instructions = data.getInstructions().get(0);
+        assertNotNull(instructions);
+        assertFalse(instructions.isEmpty());
+        assertEquals(RenderInstruction.Type.APPLY_VANILLA_COLOR, instructions.get(0).getType());
+        assertEquals(10, instructions.get(0).getParameter());
+    }
+
+    @Test
+    public void testSectionSignEffectInstruction() {
+        RenderTextData data = RenderTextProcessor.prepare("§gWave", false);
+        assertFalse(data.shouldReplaceText());
+        assertTrue(data.hasInstructions());
+        List<RenderInstruction> instructions = data.getInstructions().get(0);
+        assertNotNull(instructions);
+        assertFalse(instructions.isEmpty());
+        assertEquals(RenderInstruction.Type.SET_RAINBOW, instructions.get(0).getType());
+    }
+
+    @Test
+    public void testDinnerboneInstructionRaw() {
+        RenderTextData data = RenderTextProcessor.prepare("&hFlip", true);
+        assertFalse(data.shouldReplaceText());
+        assertTrue(data.hasInstructions());
+        List<RenderInstruction> instructions = data.getInstructions().get(0);
+        assertNotNull(instructions);
+        boolean found = false;
+        for (RenderInstruction instruction : instructions) {
+            if (instruction.getType() == RenderInstruction.Type.SET_DINNERBONE) {
+                assertTrue(instruction.isEnabled());
+                found = true;
+            }
+        }
+        assertTrue("Expected dinnerbone instruction", found);
+    }
+
+    @Test
+    public void testRawResetInstructionProducesInstruction() {
+        RenderTextData data = RenderTextProcessor.prepare("&rTest", true);
+        assertFalse(data.shouldReplaceText());
+        assertTrue(data.hasInstructions());
+        List<RenderInstruction> instructions = data.getInstructions().get(0);
+        assertNotNull(instructions);
+        assertFalse(instructions.isEmpty());
+        RenderInstruction instruction = instructions.get(0);
+        assertEquals(RenderInstruction.Type.RESET_TO_BASE, instruction.getType());
+        assertTrue(instruction.resetsFormatting());
+    }
+
+    @Test
+    public void testIgniteAndShakeInstructionsExist() {
+        RenderTextData data = RenderTextProcessor.prepare("&iFire &jShake", false);
+        assertTrue(data.shouldReplaceText());
+        assertEquals("Fire Shake", data.getDisplayText());
+        assertTrue(data.hasInstructions());
+        assertTrue(data.getInstructions().containsKey(0));
+        boolean sawIgnite = false;
+        for (RenderInstruction instruction : data.getInstructions().get(0)) {
+            if (instruction.getType() == RenderInstruction.Type.SET_IGNITE) {
+                sawIgnite = true;
+            }
+        }
+        assertTrue("Expected ignite instruction", sawIgnite);
+        int shakeIndex = data.getDisplayText().indexOf('S');
+        assertTrue(data.getInstructions().containsKey(shakeIndex));
+        boolean sawShake = false;
+        for (RenderInstruction instruction : data.getInstructions().get(shakeIndex)) {
+            if (instruction.getType() == RenderInstruction.Type.SET_SHAKE) {
+                sawShake = true;
+            }
+        }
+        assertTrue("Expected shake instruction", sawShake);
+    }
 }

--- a/src/test/java/kamkeel/hextext/client/support/SimpleCharWidthFunction.java
+++ b/src/test/java/kamkeel/hextext/client/support/SimpleCharWidthFunction.java
@@ -1,0 +1,29 @@
+package kamkeel.hextext.client.support;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import kamkeel.hextext.client.FormattedTextMetrics;
+
+public final class SimpleCharWidthFunction implements FormattedTextMetrics.CharWidthFunction {
+
+    private final float defaultWidth;
+    private final Map<Character, Float> overrides = new HashMap<Character, Float>();
+
+    public SimpleCharWidthFunction(float defaultWidth) {
+        this.defaultWidth = defaultWidth;
+    }
+
+    public void setWidth(char character, float width) {
+        overrides.put(Character.valueOf(character), Float.valueOf(width));
+    }
+
+    @Override
+    public float getWidth(char character) {
+        Float override = overrides.get(Character.valueOf(character));
+        if (override != null) {
+            return override.floatValue();
+        }
+        return defaultWidth;
+    }
+}

--- a/src/test/java/kamkeel/hextext/util/ColorMathTest.java
+++ b/src/test/java/kamkeel/hextext/util/ColorMathTest.java
@@ -1,0 +1,26 @@
+package kamkeel.hextext.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ColorMathTest {
+
+    @Test
+    public void scaleBrightnessDarkensColour() {
+        int darkened = ColorMath.scaleBrightness(0xFF8040, 0.5f);
+        assertEquals(0x804020, darkened);
+    }
+
+    @Test
+    public void scaleBrightnessClampsWhenBrightening() {
+        int brightened = ColorMath.scaleBrightness(0x808080, 3.0f);
+        assertEquals(0xFFFFFF, brightened);
+    }
+
+    @Test
+    public void blendInterpolatesBetweenColours() {
+        int blended = ColorMath.blend(0x000000, 0xFFFFFF, 0.5f);
+        assertEquals(0x808080, blended);
+    }
+}

--- a/src/test/java/kamkeel/hextext/util/StringUtilsTest.java
+++ b/src/test/java/kamkeel/hextext/util/StringUtilsTest.java
@@ -2,31 +2,49 @@ package kamkeel.hextext.util;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class StringUtilsTest {
 
     @Test
-    public void testNormalizeForRawDisplay() {
-        assertEquals("&aHello", StringUtils.normalizeForRawDisplay("§aHello"));
-        assertEquals("plain", StringUtils.normalizeForRawDisplay("plain"));
+    public void extractFormatKeepsLatestColour() {
+        String input = "&a&lBold<123456>Still";
+        String prefix = StringUtils.extractFormatFromString(input);
+        assertEquals("<123456>", prefix);
     }
 
     @Test
-    public void testExtractFormatFromString() {
-        String colorOnly = "&aHello";
-        assertEquals("&a", StringUtils.extractFormatFromString(colorOnly));
-
-        String input = "&bTest &lWorld";
-        assertEquals("&b&l", StringUtils.extractFormatFromString(input));
-
-        String nested = "<ABCDEF>Color</ABCDEF> &nUnder";
-        assertEquals("&n", StringUtils.extractFormatFromString(nested));
+    public void extractFormatClearsOnReset() {
+        String input = "&aGreen&rPlain";
+        String prefix = StringUtils.extractFormatFromString(input);
+        assertTrue(prefix.isEmpty());
     }
 
     @Test
-    public void testStripColorCodes() {
-        String input = "&aHello<ABCDEF>World</ABCDEF>&r!";
-        assertEquals("HelloWorld!", StringUtils.stripColorCodes(input));
+    public void extractFormatPreservesStyles() {
+        String input = "&a&lBold";
+        String prefix = StringUtils.extractFormatFromString(input);
+        assertEquals("&a&l", prefix);
+    }
+
+    @Test
+    public void extractFormatPreservesCustomEffects() {
+        String input = "&e&o&jHello";
+        String prefix = StringUtils.extractFormatFromString(input);
+        assertEquals("&e&o&j", prefix);
+    }
+
+    @Test
+    public void extractFormatTreatsRainbowAsColour() {
+        String input = "&lBold&gRainbow";
+        String prefix = StringUtils.extractFormatFromString(input);
+        assertEquals("&g", prefix);
+    }
+
+    @Test
+    public void normalizeForRawDisplayConvertsSectionSigns() {
+        String normalized = StringUtils.normalizeForRawDisplay("§aHello §rWorld");
+        assertEquals("&aHello &rWorld", normalized);
     }
 }

--- a/src/test/java/kamkeel/hextext/util/TextEffectMathTest.java
+++ b/src/test/java/kamkeel/hextext/util/TextEffectMathTest.java
@@ -1,0 +1,50 @@
+package kamkeel.hextext.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TextEffectMathTest {
+
+    @Test
+    public void rainbowColourKeepsBlueReadable() {
+        int color = TextEffectMath.computeRainbowColor(0L, 3000.0, 20, 0, 12.0f);
+        int red = (color >> 16) & 0xFF;
+        int green = (color >> 8) & 0xFF;
+        int blue = color & 0xFF;
+        assertTrue("Expected blue component to remain bright", blue >= 240);
+        assertTrue("Rainbow colour should retain some red for readability", red > 0);
+        assertTrue("Rainbow colour should retain some green for readability", green > 0);
+    }
+
+    @Test
+    public void igniteBrightnessFormsTriangleWave() {
+        float minFactor = 0.35f;
+        long interval = 100L;
+        assertEquals(1.0f, TextEffectMath.computeIgniteBrightness(0L, interval, minFactor), 0.0001f);
+        assertEquals(minFactor, TextEffectMath.computeIgniteBrightness(interval, interval, minFactor), 0.0001f);
+        assertEquals(1.0f, TextEffectMath.computeIgniteBrightness(interval * 2L, interval, minFactor), 0.0001f);
+        float midpoint = TextEffectMath.computeIgniteBrightness(interval / 2L, interval, minFactor);
+        float expectedMidpoint = minFactor + (1.0f - minFactor) * 0.5f;
+        assertEquals(expectedMidpoint, midpoint, 0.0001f);
+    }
+
+    @Test
+    public void shakeSeedChangesWithTimeWindow() {
+        long seedA = TextEffectMath.computeShakeSeed(2, 1000L, 100L);
+        long seedB = TextEffectMath.computeShakeSeed(2, 1200L, 100L);
+        long seedC = TextEffectMath.computeShakeSeed(3, 1000L, 100L);
+        assertTrue(seedA != seedB);
+        assertTrue(seedA != seedC);
+    }
+
+    @Test
+    public void shakeOffsetsStayWithinRange() {
+        long seed = TextEffectMath.computeShakeSeed(5, 250L, 50L);
+        float offset = TextEffectMath.computeShakeOffset(seed ^ 0xC6A4A7935BD1E995L, 1.05f);
+        assertTrue(Math.abs(offset) <= 1.05f + 1e-6f);
+        float neutral = TextEffectMath.computeShakeOffset(seed, 0.0f);
+        assertEquals(0.0f, neutral, 0.0001f);
+    }
+}


### PR DESCRIPTION
## Summary
- accumulate wrapped text widths with the same integer logic as vanilla so bold spaces and breakpoints match the book editor
- add randomized regression coverage that compares our computeLineBreakIndex helper against a vanilla sizeStringToWidth model

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_69014d0f4f708323984b016726646b89