### PR TITLE
Fix bold spacing reset for extended hex colour tags

### DIFF
--- a/src/main/java/kamkeel/hextext/client/FormattedTextMetrics.java
+++ b/src/main/java/kamkeel/hextext/client/FormattedTextMetrics.java
@@ -29,16 +29,7 @@ public final class FormattedTextMetrics {
             if (!rawMode) {
                 int codeLen = ColorCodeUtils.detectColorCodeLength(text, index);
                 if (codeLen > 0) {
-                    if (codeLen == 2 && index + 1 < length) {
-                        char fmt = Character.toLowerCase(text.charAt(index + 1));
-                        if (fmt == 'l') {
-                            isBold = true;
-                        } else if (fmt == 'r') {
-                            isBold = false;
-                        } else if ((fmt >= '0' && fmt <= '9') || (fmt >= 'a' && fmt <= 'f')) {
-                            isBold = false;
-                        }
-                    }
+                    isBold = updateBoldFlag(text, index, codeLen, isBold);
                     index += codeLen;
                     continue;
                 }
@@ -82,16 +73,7 @@ public final class FormattedTextMetrics {
             if (!rawMode) {
                 int codeLen = ColorCodeUtils.detectColorCodeLength(text, index);
                 if (codeLen > 0) {
-                    if (codeLen == 2 && index + 1 < length) {
-                        char fmt = Character.toLowerCase(text.charAt(index + 1));
-                        if (fmt == 'l') {
-                            isBold = true;
-                        } else if (fmt == 'r') {
-                            isBold = false;
-                        } else if ((fmt >= '0' && fmt <= '9') || (fmt >= 'a' && fmt <= 'f')) {
-                            isBold = false;
-                        }
-                    }
+                    isBold = updateBoldFlag(text, index, codeLen, isBold);
                     index += codeLen;
                     lastSafePosition = index;
                     continue;
@@ -127,5 +109,22 @@ public final class FormattedTextMetrics {
         }
 
         return length;
+    }
+
+    private static boolean updateBoldFlag(CharSequence text, int index, int codeLen, boolean currentBold) {
+        if (codeLen == 2 && index + 1 < text.length()) {
+            char fmt = Character.toLowerCase(text.charAt(index + 1));
+            if (fmt == 'l') {
+                return true;
+            }
+            if (fmt == 'r' || ColorCodeUtils.isMinecraftColorCode(fmt)) {
+                return false;
+            }
+            return currentBold;
+        }
+        if (codeLen > 2) {
+            return false;
+        }
+        return currentBold;
     }
 }

--- a/src/test/java/kamkeel/hextext/client/FormattedTextMetricsTest.java
+++ b/src/test/java/kamkeel/hextext/client/FormattedTextMetricsTest.java
@@ -42,4 +42,39 @@ public class FormattedTextMetricsTest {
         float width = FormattedTextMetrics.calculateMaxLineWidth("&lA&jB", false, widthFunction, 0.0f, 1.0f);
         assertEquals(12.0f, width, 0.0001f);
     }
+
+    @Test
+    public void boldResetsAfterHexAmpersandColour() {
+        SimpleCharWidthFunction widthFunction = new SimpleCharWidthFunction(5.0f);
+        float width = FormattedTextMetrics.calculateMaxLineWidth("&lA&123456B", false, widthFunction, 0.0f, 1.0f);
+        assertEquals(11.0f, width, 0.0001f);
+    }
+
+    @Test
+    public void boldResetsAfterAngleBracketColour() {
+        SimpleCharWidthFunction widthFunction = new SimpleCharWidthFunction(5.0f);
+        float width = FormattedTextMetrics.calculateMaxLineWidth("&lA<123456>B", false, widthFunction, 0.0f, 1.0f);
+        assertEquals(11.0f, width, 0.0001f);
+    }
+
+    @Test
+    public void boldResetsAfterClosingAngleBracketColour() {
+        SimpleCharWidthFunction widthFunction = new SimpleCharWidthFunction(5.0f);
+        float width = FormattedTextMetrics.calculateMaxLineWidth("&lA</123456>B", false, widthFunction, 0.0f, 1.0f);
+        assertEquals(11.0f, width, 0.0001f);
+    }
+
+    @Test
+    public void lineBreakKeepsCharactersAfterHexColour() {
+        SimpleCharWidthFunction widthFunction = new SimpleCharWidthFunction(5.0f);
+        int breakIndex = FormattedTextMetrics.computeLineBreakIndex("&lA&123456BC", 11, false, widthFunction, 0.0f, 1.0f);
+        assertEquals(11, breakIndex);
+    }
+
+    @Test
+    public void lineBreakKeepsCharactersAfterAngleColour() {
+        SimpleCharWidthFunction widthFunction = new SimpleCharWidthFunction(5.0f);
+        int breakIndex = FormattedTextMetrics.computeLineBreakIndex("&lA<123456>BC", 11, false, widthFunction, 0.0f, 1.0f);
+        assertEquals(12, breakIndex);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure FormattedTextMetrics resets bold mode whenever a detected colour token is processed
- add regression coverage for ampersand and angle-bracket hex colour sequences in width and line-break calculations

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_69018782cea4832397bedd5479d1d372