### PR TITLE
Reset bold spacing after extended color codes

### DIFF
--- a/src/main/java/kamkeel/hextext/client/FormattedTextMetrics.java
+++ b/src/main/java/kamkeel/hextext/client/FormattedTextMetrics.java
@@ -29,16 +29,7 @@ public final class FormattedTextMetrics {
             if (!rawMode) {
                 int codeLen = ColorCodeUtils.detectColorCodeLength(text, index);
                 if (codeLen > 0) {
-                    if (codeLen == 2 && index + 1 < length) {
-                        char fmt = Character.toLowerCase(text.charAt(index + 1));
-                        if (fmt == 'l') {
-                            isBold = true;
-                        } else if (fmt == 'r') {
-                            isBold = false;
-                        } else if ((fmt >= '0' && fmt <= '9') || (fmt >= 'a' && fmt <= 'f')) {
-                            isBold = false;
-                        }
-                    }
+                    isBold = updateBoldFlag(text, index, codeLen, isBold, length);
                     index += codeLen;
                     continue;
                 }
@@ -82,16 +73,7 @@ public final class FormattedTextMetrics {
             if (!rawMode) {
                 int codeLen = ColorCodeUtils.detectColorCodeLength(text, index);
                 if (codeLen > 0) {
-                    if (codeLen == 2 && index + 1 < length) {
-                        char fmt = Character.toLowerCase(text.charAt(index + 1));
-                        if (fmt == 'l') {
-                            isBold = true;
-                        } else if (fmt == 'r') {
-                            isBold = false;
-                        } else if ((fmt >= '0' && fmt <= '9') || (fmt >= 'a' && fmt <= 'f')) {
-                            isBold = false;
-                        }
-                    }
+                    isBold = updateBoldFlag(text, index, codeLen, isBold, length);
                     index += codeLen;
                     lastSafePosition = index;
                     continue;
@@ -127,5 +109,25 @@ public final class FormattedTextMetrics {
         }
 
         return length;
+    }
+
+    private static boolean updateBoldFlag(CharSequence text, int index, int codeLen,
+            boolean currentBold, int textLength) {
+        if (codeLen <= 0) {
+            return currentBold;
+        }
+
+        if (codeLen == 2 && index + 1 < textLength) {
+            char fmt = Character.toLowerCase(text.charAt(index + 1));
+            if (fmt == 'l') {
+                return true;
+            }
+            if (ColorCodeUtils.isResetCode(fmt) || ColorCodeUtils.isMinecraftColorCode(fmt)) {
+                return false;
+            }
+            return currentBold;
+        }
+
+        return false;
     }
 }

--- a/src/test/java/kamkeel/hextext/client/FormattedTextMetricsTest.java
+++ b/src/test/java/kamkeel/hextext/client/FormattedTextMetricsTest.java
@@ -42,4 +42,25 @@ public class FormattedTextMetricsTest {
         float width = FormattedTextMetrics.calculateMaxLineWidth("&lA&jB", false, widthFunction, 0.0f, 1.0f);
         assertEquals(12.0f, width, 0.0001f);
     }
+
+    @Test
+    public void hexColorCodesResetBoldWidth() {
+        SimpleCharWidthFunction widthFunction = new SimpleCharWidthFunction(5.0f);
+        float width = FormattedTextMetrics.calculateMaxLineWidth("&lA&123456B", false, widthFunction, 0.0f, 1.0f);
+        assertEquals(11.0f, width, 0.0001f);
+    }
+
+    @Test
+    public void tagColorCodesResetBoldWidth() {
+        SimpleCharWidthFunction widthFunction = new SimpleCharWidthFunction(5.0f);
+        float width = FormattedTextMetrics.calculateMaxLineWidth("&lA<123456>B", false, widthFunction, 0.0f, 1.0f);
+        assertEquals(11.0f, width, 0.0001f);
+    }
+
+    @Test
+    public void computeLineBreakHandlesHexColorReset() {
+        SimpleCharWidthFunction widthFunction = new SimpleCharWidthFunction(5.0f);
+        int breakIndex = FormattedTextMetrics.computeLineBreakIndex("&lA&123456BC", 11, false, widthFunction, 0.0f, 1.0f);
+        assertEquals(11, breakIndex);
+    }
 }

--- a/src/test/java/kamkeel/hextext/util/ColorCodeUtilsTest.java
+++ b/src/test/java/kamkeel/hextext/util/ColorCodeUtilsTest.java
@@ -30,11 +30,36 @@ public class ColorCodeUtilsTest {
     }
 
     @Test
-    public void testDetectColorCodeLength() {
-        assertEquals(7, ColorCodeUtils.detectColorCodeLength("&123456rest", 0));
+    public void detectLegacyFormattingCodeLength() {
+        assertEquals(2, ColorCodeUtils.detectColorCodeLength("&l", 0));
+    }
+
+    @Test
+    public void detectInlineHexColorLength() {
+        assertEquals(7, ColorCodeUtils.detectColorCodeLength("&123abc", 0));
         assertEquals(2, ColorCodeUtils.detectColorCodeLength("§ares", 0));
+    }
+
+    @Test
+    public void detectTaggedHexColorLengths() {
+        assertEquals(8, ColorCodeUtils.detectColorCodeLength("<abcdef>", 0));
+        assertEquals(9, ColorCodeUtils.detectColorCodeLength("</abcdef>", 0));
         assertEquals(9, ColorCodeUtils.detectColorCodeLength("</ABCDEF>xyz", 0));
         assertEquals(8, ColorCodeUtils.detectColorCodeLength("<ABCDEF>xyz", 0));
+    }
+
+    @Test
+    public void rawModeDisablesDetection() {
+        assertEquals(0, ColorCodeUtils.detectColorCodeLength("&123abc", 0, true));
+    }
+
+    @Test
+    public void validatesHexStrings() {
+        assertTrue(ColorCodeUtils.isValidHexString("a1b2c3"));
+    }
+
+    @Test
+    public void detectPlainTextHasNoCode() {
         assertEquals(0, ColorCodeUtils.detectColorCodeLength("plain", 0));
     }
 


### PR DESCRIPTION
## Summary
- reset the bold flag in FormattedTextMetrics when encountering extended RGB color tokens
- add regression tests covering bold measurement with inline and tagged RGB colours
- expand ColorCodeUtils tests for formatting detection and helper methods

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_69018782cea4832397bedd5479d1d372