### PR TITLE
Normalize ampersand formatting codes during size measurements

### DIFF
--- a/src/main/java/kamkeel/hextext/client/FontRendererUtils.java
+++ b/src/main/java/kamkeel/hextext/client/FontRendererUtils.java
@@ -19,12 +19,14 @@ public final class FontRendererUtils {
     }
 
     public static float calculateMaxLineWidth(FontRenderer renderer, String text, boolean rawMode) {
-        return FormattedTextMetrics.calculateMaxLineWidth(text, rawMode,
+        String processed = StringUtils.convertLegacyFormattingCodes(text);
+        return FormattedTextMetrics.calculateMaxLineWidth(processed, rawMode,
             character -> getCharWidth(renderer, character, rawMode), 0.0f, 1.0f);
     }
 
     public static int computeLineBreakIndex(FontRenderer renderer, String text, int maxWidth, boolean rawMode) {
-        return FormattedTextMetrics.computeLineBreakIndex(text, maxWidth, rawMode,
+        String processed = StringUtils.convertLegacyFormattingCodes(text);
+        return FormattedTextMetrics.computeLineBreakIndex(processed, maxWidth, rawMode,
             character -> getCharWidth(renderer, character, rawMode), 0.0f, 1.0f);
     }
 

--- a/src/main/java/kamkeel/hextext/util/StringUtils.java
+++ b/src/main/java/kamkeel/hextext/util/StringUtils.java
@@ -42,6 +42,39 @@ public final class StringUtils {
         return builder == null ? text : builder.toString();
     }
 
+    public static String convertLegacyFormattingCodes(String text) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+
+        StringBuilder builder = null;
+        int length = text.length();
+
+        for (int i = 0; i < length; i++) {
+            char current = text.charAt(i);
+
+            if (current == '&' && i + 1 < length) {
+                char next = text.charAt(i + 1);
+                if (ColorCodeUtils.isFormattingCode(next)) {
+                    if (builder == null) {
+                        builder = new StringBuilder(length);
+                        builder.append(text, 0, i);
+                    }
+                    builder.append('§');
+                    builder.append(next);
+                    i++;
+                    continue;
+                }
+            }
+
+            if (builder != null) {
+                builder.append(current);
+            }
+        }
+
+        return builder == null ? text : builder.toString();
+    }
+
     public static String extractFormatFromString(String str) {
         if (str == null || str.isEmpty()) {
             return "";

--- a/src/test/java/kamkeel/hextext/util/StringUtilsTest.java
+++ b/src/test/java/kamkeel/hextext/util/StringUtilsTest.java
@@ -47,4 +47,16 @@ public class StringUtilsTest {
         String normalized = StringUtils.normalizeForRawDisplay("§aHello §rWorld");
         assertEquals("&aHello &rWorld", normalized);
     }
+
+    @Test
+    public void convertLegacyFormattingCodesReplacesAmpersands() {
+        String converted = StringUtils.convertLegacyFormattingCodes("&lBold &NA");
+        assertEquals("§lBold §NA", converted);
+    }
+
+    @Test
+    public void convertLegacyFormattingCodesIgnoresNonFormattingAmpersands() {
+        String converted = StringUtils.convertLegacyFormattingCodes("Fish & Chips");
+        assertEquals("Fish & Chips", converted);
+    }
 }


### PR DESCRIPTION
## Summary
- convert ampersand-based formatting sequences to section sign codes before running width and line-break calculations
- add a utility helper for normalising legacy formatting markers and cover it with unit tests

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_69018b5a8f808323bfe9c818a57e89c9