### PR TITLE
Normalize ampersand formatting output for legacy callers

### DIFF
--- a/src/main/java/kamkeel/hextext/client/FontRendererUtils.java
+++ b/src/main/java/kamkeel/hextext/client/FontRendererUtils.java
@@ -30,7 +30,7 @@ public final class FontRendererUtils {
 
     public static String trimStringFromEnd(FontRenderer renderer, String text, int width, boolean rawMode) {
         if (text == null || text.isEmpty()) {
-            return "";
+            return finalizeResult("", rawMode);
         }
 
         float currentWidth = 0.0f;
@@ -92,7 +92,7 @@ public final class FontRendererUtils {
             }
 
             if (chr == '\n') {
-                return text.substring(index + 1);
+                return finalizeResult(text.substring(index + 1), rawMode);
             }
 
             float glyphWidth = getCharWidth(renderer, chr, rawMode);
@@ -106,7 +106,7 @@ public final class FontRendererUtils {
             }
 
             if (nextWidth > width) {
-                return text.substring(firstSafePosition);
+                return finalizeResult(text.substring(firstSafePosition), rawMode);
             }
 
             currentWidth = nextWidth;
@@ -114,17 +114,17 @@ public final class FontRendererUtils {
             index--;
         }
 
-        return text;
+        return finalizeResult(text, rawMode);
     }
 
     public static String wrapFormattedString(FontRenderer renderer, String text, int wrapWidth, boolean rawMode) {
         if (text == null || text.isEmpty()) {
-            return "";
+            return finalizeResult("", rawMode);
         }
 
         int breakPoint = computeLineBreakIndex(renderer, text, wrapWidth, rawMode);
         if (breakPoint >= text.length()) {
-            return text;
+            return finalizeResult(text, rawMode);
         }
 
         String firstPart = text.substring(0, breakPoint);
@@ -135,9 +135,59 @@ public final class FontRendererUtils {
             + text.substring(breakPoint + (skipChar ? 1 : 0));
 
         if (remainder.length() == text.length()) {
-            return firstPart + "\n" + remainder;
+            return finalizeResult(firstPart + "\n" + remainder, rawMode);
         }
 
-        return firstPart + "\n" + wrapFormattedString(renderer, remainder, wrapWidth, rawMode);
+        String result = firstPart + "\n" + wrapFormattedString(renderer, remainder, wrapWidth, rawMode);
+        return finalizeResult(result, rawMode);
+    }
+
+    public static String convertLegacyFormattingCodes(String text) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+
+        StringBuilder builder = null;
+        int length = text.length();
+
+        for (int index = 0; index < length; index++) {
+            char current = text.charAt(index);
+
+            if (current == '&') {
+                if (index + 7 <= length && ColorCodeUtils.isValidHexString(text, index + 1)) {
+                    if (builder != null) {
+                        builder.append(text, index, index + 7);
+                    }
+                    index += 6;
+                    continue;
+                }
+
+                if (index + 1 < length) {
+                    char next = text.charAt(index + 1);
+                    if (ColorCodeUtils.isFormattingCode(next)) {
+                        if (builder == null) {
+                            builder = new StringBuilder(length);
+                            builder.append(text, 0, index);
+                        }
+                        builder.append('§').append(next);
+                        index++;
+                        continue;
+                    }
+                }
+            }
+
+            if (builder != null) {
+                builder.append(current);
+            }
+        }
+
+        return builder == null ? text : builder.toString();
+    }
+
+    private static String finalizeResult(String result, boolean rawMode) {
+        if (result == null || result.isEmpty() || rawMode) {
+            return result;
+        }
+        return convertLegacyFormattingCodes(result);
     }
 }

--- a/src/main/java/kamkeel/hextext/mixins/early/impl/client/MixinFontRenderer.java
+++ b/src/main/java/kamkeel/hextext/mixins/early/impl/client/MixinFontRenderer.java
@@ -193,7 +193,11 @@ public abstract class MixinFontRenderer {
         if (!reverse) {
             boolean rawMode = FontRenderContext.isRawTextRendering();
             int endIndex = FontRendererUtils.computeLineBreakIndex((FontRenderer) (Object) this, text, width, rawMode);
-            cir.setReturnValue(text.substring(0, Math.min(endIndex, text.length())));
+            String result = text.substring(0, Math.min(endIndex, text.length()));
+            if (!rawMode) {
+                result = FontRendererUtils.convertLegacyFormattingCodes(result);
+            }
+            cir.setReturnValue(result);
             return;
         }
 


### PR DESCRIPTION
## Summary
- ensure `trimStringFromEnd` and `wrapFormattedString` convert legacy `&` formatting codes to the section sign when not in raw mode
- add a reusable formatter that leaves hex colour tokens intact but normalises `&` style/colour codes
- update the font renderer mixin so forward `trimStringToWidth` results go through the normaliser, matching vanilla expectations for downstream consumers

## Testing
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_69019398d89c8323a0a4b2116913a798