### PR TITLE
Normalize ampersand formatting before measuring text

### DIFF
--- a/src/main/java/kamkeel/hextext/client/FontRendererUtils.java
+++ b/src/main/java/kamkeel/hextext/client/FontRendererUtils.java
@@ -19,12 +19,14 @@ public final class FontRendererUtils {
     }
 
     public static float calculateMaxLineWidth(FontRenderer renderer, String text, boolean rawMode) {
-        return FormattedTextMetrics.calculateMaxLineWidth(text, rawMode,
+        String normalized = normalizeTextForMetrics(text, rawMode);
+        return FormattedTextMetrics.calculateMaxLineWidth(normalized, rawMode,
             character -> getCharWidth(renderer, character, rawMode), 0.0f, 1.0f);
     }
 
     public static int computeLineBreakIndex(FontRenderer renderer, String text, int maxWidth, boolean rawMode) {
-        return FormattedTextMetrics.computeLineBreakIndex(text, maxWidth, rawMode,
+        String normalized = normalizeTextForMetrics(text, rawMode);
+        return FormattedTextMetrics.computeLineBreakIndex(normalized, maxWidth, rawMode,
             character -> getCharWidth(renderer, character, rawMode), 0.0f, 1.0f);
     }
 
@@ -33,22 +35,23 @@ public final class FontRendererUtils {
             return "";
         }
 
+        String normalized = normalizeTextForMetrics(text, rawMode);
         float currentWidth = 0.0f;
         int firstSafePosition = text.length();
         boolean bold = false;
 
         for (int index = text.length() - 1; index >= 0; ) {
-            char chr = text.charAt(index);
+            char chr = normalized.charAt(index);
 
             if (!rawMode) {
-                if (index >= 6 && text.charAt(index - 6) == '&' && ColorCodeUtils.isValidHexString(text, index - 5)) {
+                if (index >= 6 && normalized.charAt(index - 6) == '&' && ColorCodeUtils.isValidHexString(normalized, index - 5)) {
                     index -= 7;
                     firstSafePosition = index + 1;
                     bold = false;
                     continue;
                 }
 
-                if (index >= 1 && text.charAt(index - 1) == 167) {
+                if (index >= 1 && normalized.charAt(index - 1) == 167) {
                     char fmt = Character.toLowerCase(chr);
                     if (fmt == 'l') {
                         bold = true;
@@ -60,23 +63,23 @@ public final class FontRendererUtils {
                     continue;
                 }
 
-                if (index >= 7 && text.charAt(index - 7) == '<' && text.charAt(index) == '>'
-                    && ColorCodeUtils.isValidHexString(text, index - 6)) {
+                if (index >= 7 && normalized.charAt(index - 7) == '<' && normalized.charAt(index) == '>'
+                    && ColorCodeUtils.isValidHexString(normalized, index - 6)) {
                     index -= 8;
                     firstSafePosition = index + 1;
                     bold = false;
                     continue;
                 }
 
-                if (index >= 8 && text.charAt(index - 8) == '<' && text.charAt(index - 7) == '/'
-                    && text.charAt(index) == '>' && ColorCodeUtils.isValidHexString(text, index - 6)) {
+                if (index >= 8 && normalized.charAt(index - 8) == '<' && normalized.charAt(index - 7) == '/'
+                    && normalized.charAt(index) == '>' && ColorCodeUtils.isValidHexString(normalized, index - 6)) {
                     index -= 9;
                     firstSafePosition = index + 1;
                     bold = false;
                     continue;
                 }
 
-                if (index >= 1 && text.charAt(index - 1) == '&') {
+                if (index >= 1 && normalized.charAt(index - 1) == '&') {
                     char fmt = Character.toLowerCase(chr);
                     if (ColorCodeUtils.isFormattingCode(fmt)) {
                         if (fmt == 'l') {
@@ -127,8 +130,9 @@ public final class FontRendererUtils {
             return text;
         }
 
+        String normalized = normalizeTextForMetrics(text, rawMode);
         String firstPart = text.substring(0, breakPoint);
-        char breakChar = text.charAt(breakPoint);
+        char breakChar = normalized.charAt(breakPoint);
         boolean skipChar = breakChar == ' ' || breakChar == '\n';
 
         String remainder = StringUtils.extractFormatFromString(firstPart)
@@ -139,5 +143,12 @@ public final class FontRendererUtils {
         }
 
         return firstPart + "\n" + wrapFormattedString(renderer, remainder, wrapWidth, rawMode);
+    }
+
+    private static String normalizeTextForMetrics(String text, boolean rawMode) {
+        if (text == null || rawMode) {
+            return text;
+        }
+        return StringUtils.normalizeLegacyFormattingCodes(text);
     }
 }

--- a/src/main/java/kamkeel/hextext/util/StringUtils.java
+++ b/src/main/java/kamkeel/hextext/util/StringUtils.java
@@ -105,6 +105,38 @@ public final class StringUtils {
         return result.toString();
     }
 
+    public static String normalizeLegacyFormattingCodes(String text) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+
+        StringBuilder builder = null;
+        final int length = text.length();
+
+        for (int index = 0; index < length - 1; index++) {
+            if (text.charAt(index) != '&') {
+                continue;
+            }
+
+            if (ColorCodeUtils.isValidHexString(text, index + 1)) {
+                index += 6;
+                continue;
+            }
+
+            char next = text.charAt(index + 1);
+            if (!ColorCodeUtils.isFormattingCode(next)) {
+                continue;
+            }
+
+            if (builder == null) {
+                builder = new StringBuilder(text);
+            }
+            builder.setCharAt(index, '\u00a7');
+        }
+
+        return builder == null ? text : builder.toString();
+    }
+
     public static String stripColorCodes(CharSequence input) {
         if (input == null) {
             return null;


### PR DESCRIPTION
## Summary
- add a utility to convert legacy ampersand formatting markers to section signs without touching RGB tokens
- normalize strings prior to width calculations and trimming so ampersand bold codes measure consistently

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_e_69019398d89c8323a0a4b2116913a798