### PR TITLE
Normalize legacy format prefixes to section sign

### DIFF
--- a/src/main/java/kamkeel/hextext/util/StringUtils.java
+++ b/src/main/java/kamkeel/hextext/util/StringUtils.java
@@ -73,9 +73,10 @@ public final class StringUtils {
                     styleCodes.setLength(0);
                 } else if (codeLen == 2) {
                     char fmt = Character.toLowerCase(str.charAt(i + 1));
+                    String canonical = canonicalizeLegacyCode(str.charAt(i + 1));
 
                     if (ColorCodeUtils.isMinecraftColorCode(fmt) || fmt == 'g') {
-                        currentColorCode = code;
+                        currentColorCode = canonical;
                         colorStack.clear();
                         styleCodes.setLength(0);
                     } else if (ColorCodeUtils.isResetCode(fmt)) {
@@ -83,7 +84,7 @@ public final class StringUtils {
                         colorStack.clear();
                         styleCodes.setLength(0);
                     } else if (ColorCodeUtils.isStyleCode(fmt) || ColorCodeUtils.isEffectCode(fmt)) {
-                        styleCodes.append(code);
+                        styleCodes.append(canonical);
                     }
                 }
 
@@ -123,5 +124,9 @@ public final class StringUtils {
         }
 
         return builder.toString();
+    }
+
+    private static String canonicalizeLegacyCode(char codeChar) {
+        return new String(new char[] {'§', codeChar});
     }
 }

--- a/src/test/java/kamkeel/hextext/util/StringUtilsTest.java
+++ b/src/test/java/kamkeel/hextext/util/StringUtilsTest.java
@@ -25,21 +25,21 @@ public class StringUtilsTest {
     public void extractFormatPreservesStyles() {
         String input = "&a&lBold";
         String prefix = StringUtils.extractFormatFromString(input);
-        assertEquals("&a&l", prefix);
+        assertEquals("§a§l", prefix);
     }
 
     @Test
     public void extractFormatIncludesEffects() {
         String input = "&e&o&jHello";
         String prefix = StringUtils.extractFormatFromString(input);
-        assertEquals("&e&o&j", prefix);
+        assertEquals("§e§o§j", prefix);
     }
 
     @Test
     public void extractFormatTreatsRainbowAsColour() {
         String input = "&g&iFlicker";
         String prefix = StringUtils.extractFormatFromString(input);
-        assertEquals("&g&i", prefix);
+        assertEquals("§g§i", prefix);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- canonicalize legacy formatting codes to section sign-prefixed sequences when extracting formatting context
- update StringUtils tests to expect the canonical prefixes

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_6901939a868483238ff59100f530a2ba