### PR TITLE
Add reusable formatting utilities for HexText consumers

### DIFF
--- a/src/main/java/kamkeel/hextext/common/util/ColorCodeUtils.java
+++ b/src/main/java/kamkeel/hextext/common/util/ColorCodeUtils.java
@@ -76,6 +76,22 @@ public final class ColorCodeUtils {
         return Character.toLowerCase(c) == 'r';
     }
 
+    public static String translateAlternateColorCodes(char alternateChar, String text) {
+        if (text == null) {
+            return null;
+        }
+
+        char[] characters = text.toCharArray();
+        for (int i = 0; i < characters.length - 1; i++) {
+            if (characters[i] == alternateChar && isFormattingCode(characters[i + 1])) {
+                characters[i] = 167;
+                characters[i + 1] = Character.toLowerCase(characters[i + 1]);
+            }
+        }
+
+        return new String(characters);
+    }
+
     public static int parseHexColor(String hex) {
         if (!isValidHexString(hex)) {
             return -1;
@@ -178,5 +194,13 @@ public final class ColorCodeUtils {
         int blue = (int) (b * 255);
 
         return (red << 16) | (green << 8) | blue;
+    }
+
+    public static String toHexString(int rgb) {
+        return String.format("%06X", rgb & 0x00FFFFFF);
+    }
+
+    public static String formatHexColor(int rgb) {
+        return "<#" + toHexString(rgb) + ">";
     }
 }

--- a/src/main/java/kamkeel/hextext/common/util/StringUtils.java
+++ b/src/main/java/kamkeel/hextext/common/util/StringUtils.java
@@ -124,4 +124,41 @@ public final class StringUtils {
 
         return builder.toString();
     }
+
+    public static boolean containsColorCodes(CharSequence input) {
+        if (input == null || input.length() == 0) {
+            return false;
+        }
+
+        for (int index = 0; index < input.length(); ) {
+            int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(input, index);
+            if (codeLen > 0) {
+                return true;
+            }
+
+            char current = input.charAt(index);
+            if (current == 167) {
+                if (index + 1 < input.length()) {
+                    char next = input.charAt(index + 1);
+                    if (ColorCodeUtils.isFormattingCode(next)) {
+                        return true;
+                    }
+                }
+                return true;
+            }
+
+            index++;
+        }
+
+        return false;
+    }
+
+    public static String stripExtras(CharSequence input) {
+        String stripped = stripColorCodes(input);
+        if (stripped == null || stripped.indexOf(167) < 0) {
+            return stripped;
+        }
+
+        return stripped.replace(String.valueOf((char) 167), "");
+    }
 }

--- a/src/test/java/kamkeel/hextext/common/util/ColorCodeUtilsTest.java
+++ b/src/test/java/kamkeel/hextext/common/util/ColorCodeUtilsTest.java
@@ -42,4 +42,27 @@ public class ColorCodeUtilsTest {
     public void testCalculateShadowColor() {
         assertEquals(0x1E1E1E, ColorCodeUtils.calculateShadowColor(0x7A7A7A));
     }
+
+    @Test
+    public void translateAlternateColorCodesConvertsToSectionSymbols() {
+        String input = "&aHello &lWorld";
+        String result = ColorCodeUtils.translateAlternateColorCodes('&', input);
+        assertEquals("§aHello §lWorld", result);
+    }
+
+    @Test
+    public void translateAlternateColorCodesHandlesNullInput() {
+        assertNull(ColorCodeUtils.translateAlternateColorCodes('&', null));
+    }
+
+    @Test
+    public void toHexStringProducesUppercaseValues() {
+        assertEquals("ABCDEF", ColorCodeUtils.toHexString(0xABCDEF));
+        assertEquals("0000FF", ColorCodeUtils.toHexString(0x0000FF));
+    }
+
+    @Test
+    public void formatHexColorWrapsWithBrackets() {
+        assertEquals("<#123456>", ColorCodeUtils.formatHexColor(0x123456));
+    }
 }

--- a/src/test/java/kamkeel/hextext/common/util/StringUtilsTest.java
+++ b/src/test/java/kamkeel/hextext/common/util/StringUtilsTest.java
@@ -2,8 +2,7 @@ package kamkeel.hextext.common.util;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class StringUtilsTest {
 
@@ -46,5 +45,26 @@ public class StringUtilsTest {
     public void normalizeForRawDisplayConvertsSectionSigns() {
         String normalized = StringUtils.normalizeForRawDisplay("§aHello §rWorld");
         assertEquals("&aHello &rWorld", normalized);
+    }
+
+    @Test
+    public void stripColorCodesRemovesMinecraftFormatting() {
+        String input = "&aGreen <#FFAA00>and &lBold";
+        String result = StringUtils.stripColorCodes(input);
+        assertEquals("Green and Bold", result);
+    }
+
+    @Test
+    public void containsColorCodesDetectsHexAndLegacyCodes() {
+        assertTrue(StringUtils.containsColorCodes("<#123456>Fancy"));
+        assertTrue(StringUtils.containsColorCodes("&aHello"));
+        assertFalse(StringUtils.containsColorCodes("No formatting here"));
+    }
+
+    @Test
+    public void stripExtrasRemovesStraySectionCharacters() {
+        String input = "Text with stray " + (char) 167 + " section";
+        String result = StringUtils.stripExtras(input);
+        assertEquals("Text with stray  section", result);
     }
 }


### PR DESCRIPTION
## Summary
- add StringUtils helpers for detecting and stripping formatting codes
- expose ColorCodeUtils utilities for alternate codes and RGB formatting strings
- extend unit tests to cover the new helper behaviour

## Testing
- ./gradlew test *(fails: mixin annotation processor cannot locate obfuscation mapping for FontRenderer#doDraw)*

------
https://chatgpt.com/codex/tasks/task_e_6901acf9f01c8323888dc380a56c5d4e