### PR TITLE
Add formatting utility helpers to HexText

### DIFF
--- a/src/main/java/kamkeel/hextext/common/util/ColorCodeUtils.java
+++ b/src/main/java/kamkeel/hextext/common/util/ColorCodeUtils.java
@@ -179,4 +179,46 @@ public final class ColorCodeUtils {
 
         return (red << 16) | (green << 8) | blue;
     }
+
+    /**
+     * Checks if the supplied character sequence contains any recognised Minecraft or HexText
+     * formatting tokens.
+     *
+     * @param input sequence to inspect
+     * @return {@code true} when a formatting token is encountered, {@code false} otherwise
+     */
+    public static boolean containsFormattingCodes(CharSequence input) {
+        if (input == null || input.length() == 0) {
+            return false;
+        }
+
+        for (int index = 0; index < input.length(); index++) {
+            if (detectColorCodeLengthIgnoringRaw(input, index) > 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Finds the index of the first formatting token at or after {@code start}.
+     *
+     * @param input sequence to inspect
+     * @param start index to begin searching from
+     * @return the index of the first token or {@code -1} when none exist in the range
+     */
+    public static int indexOfNextFormattingCode(CharSequence input, int start) {
+        if (input == null || start < 0 || start >= input.length()) {
+            return -1;
+        }
+
+        for (int index = start; index < input.length(); index++) {
+            if (detectColorCodeLengthIgnoringRaw(input, index) > 0) {
+                return index;
+            }
+        }
+
+        return -1;
+    }
 }

--- a/src/main/java/kamkeel/hextext/common/util/StringUtils.java
+++ b/src/main/java/kamkeel/hextext/common/util/StringUtils.java
@@ -124,4 +124,131 @@ public final class StringUtils {
 
         return builder.toString();
     }
+
+    /**
+     * Removes all recognised formatting tokens from the provided text. This is an alias for
+     * {@link #stripColorCodes(CharSequence)} that reads more clearly in contexts where any
+     * non-textual extras should be discarded.
+     */
+    public static String stripExtras(CharSequence input) {
+        return stripColorCodes(input);
+    }
+
+    /**
+     * Removes colour-related formatting codes while preserving styles such as bold/italic.
+     */
+    public static String stripHexColors(CharSequence input) {
+        if (input == null) {
+            return null;
+        }
+
+        StringBuilder builder = null;
+        int index = 0;
+        while (index < input.length()) {
+            int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(input, index);
+            if (codeLen > 0) {
+                if (isHexColorToken(input, index, codeLen)) {
+                    if (builder == null) {
+                        builder = new StringBuilder(input.length());
+                        builder.append(input, 0, index);
+                    }
+                    index += codeLen;
+                    continue;
+                }
+
+                if (builder != null) {
+                    builder.append(input, index, index + codeLen);
+                }
+                index += codeLen;
+                continue;
+            }
+
+            if (builder != null) {
+                builder.append(input.charAt(index));
+            }
+            index++;
+        }
+
+        return builder == null ? input.toString() : builder.toString();
+    }
+
+    /**
+     * Removes style/effect formatting codes (bold, italic, rainbow etc.) while leaving colours
+     * untouched.
+     */
+    public static String stripStyles(CharSequence input) {
+        if (input == null) {
+            return null;
+        }
+
+        StringBuilder builder = null;
+        int index = 0;
+        while (index < input.length()) {
+            int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(input, index);
+            if (codeLen > 0) {
+                if (isStyleOrEffectToken(input, index, codeLen)) {
+                    if (builder == null) {
+                        builder = new StringBuilder(input.length());
+                        builder.append(input, 0, index);
+                    }
+                    index += codeLen;
+                    continue;
+                }
+
+                if (builder != null) {
+                    builder.append(input, index, index + codeLen);
+                }
+                index += codeLen;
+                continue;
+            }
+
+            if (builder != null) {
+                builder.append(input.charAt(index));
+            }
+            index++;
+        }
+
+        return builder == null ? input.toString() : builder.toString();
+    }
+
+    /**
+     * @return {@code true} when the input contains any formatting codes understood by HexText.
+     */
+    public static boolean containsFormattingCodes(CharSequence input) {
+        return ColorCodeUtils.containsFormattingCodes(input);
+    }
+
+    private static boolean isHexColorToken(CharSequence input, int index, int codeLen) {
+        char start = input.charAt(index);
+        if (codeLen == 7 && start == '&') {
+            return true;
+        }
+
+        if (codeLen == 8 && start == '<') {
+            return true;
+        }
+
+        if (codeLen == 9 && start == '<') {
+            return true;
+        }
+
+        if (codeLen == 2 && (start == '&' || start == 167)) {
+            char fmt = Character.toLowerCase(input.charAt(index + 1));
+            return ColorCodeUtils.isMinecraftColorCode(fmt) || fmt == 'g';
+        }
+
+        return false;
+    }
+
+    private static boolean isStyleOrEffectToken(CharSequence input, int index, int codeLen) {
+        if (codeLen == 2) {
+            char start = input.charAt(index);
+            if (start == '&' || start == 167) {
+                char fmt = Character.toLowerCase(input.charAt(index + 1));
+                return ColorCodeUtils.isStyleCode(fmt) || ColorCodeUtils.isEffectCode(fmt);
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/test/java/kamkeel/hextext/common/util/ColorCodeUtilsTest.java
+++ b/src/test/java/kamkeel/hextext/common/util/ColorCodeUtilsTest.java
@@ -42,4 +42,17 @@ public class ColorCodeUtilsTest {
     public void testCalculateShadowColor() {
         assertEquals(0x1E1E1E, ColorCodeUtils.calculateShadowColor(0x7A7A7A));
     }
+
+    @Test
+    public void testContainsFormattingCodes() {
+        assertTrue(ColorCodeUtils.containsFormattingCodes("Hello &aWorld"));
+        assertFalse(ColorCodeUtils.containsFormattingCodes("Plain text"));
+    }
+
+    @Test
+    public void testIndexOfNextFormattingCode() {
+        assertEquals(6, ColorCodeUtils.indexOfNextFormattingCode("Hello &aWorld", 0));
+        assertEquals(-1, ColorCodeUtils.indexOfNextFormattingCode("Plain", 0));
+        assertEquals(-1, ColorCodeUtils.indexOfNextFormattingCode("Hello &aWorld", 20));
+    }
 }

--- a/src/test/java/kamkeel/hextext/common/util/StringUtilsTest.java
+++ b/src/test/java/kamkeel/hextext/common/util/StringUtilsTest.java
@@ -2,8 +2,7 @@ package kamkeel.hextext.common.util;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class StringUtilsTest {
 
@@ -46,5 +45,29 @@ public class StringUtilsTest {
     public void normalizeForRawDisplayConvertsSectionSigns() {
         String normalized = StringUtils.normalizeForRawDisplay("§aHello §rWorld");
         assertEquals("&aHello &rWorld", normalized);
+    }
+
+    @Test
+    public void stripExtrasRemovesAllFormatting() {
+        String input = "&a&lBold <123456>Text&n";
+        assertEquals("Bold Text", StringUtils.stripExtras(input));
+    }
+
+    @Test
+    public void stripHexColorsPreservesStyles() {
+        String input = "&a&lHello <123456>World</123456>";
+        assertEquals("&lHello World", StringUtils.stripHexColors(input));
+    }
+
+    @Test
+    public void stripStylesKeepsColours() {
+        String input = "&a&lBold&o Text";
+        assertEquals("&aBold Text", StringUtils.stripStyles(input));
+    }
+
+    @Test
+    public void containsFormattingCodesDetectsTokens() {
+        assertTrue(StringUtils.containsFormattingCodes("Plain &aColour"));
+        assertFalse(StringUtils.containsFormattingCodes("Plain text"));
     }
 }


### PR DESCRIPTION
## Summary
- expose helpers on `ColorCodeUtils` for detecting the presence or position of formatting tokens
- add string helpers such as `stripExtras`, `stripHexColors`, and `stripStyles` for broader reuse
- extend unit coverage to exercise the new utility surface

## Testing
- ./gradlew test *(fails: mixin annotation processor cannot resolve obfuscation targets in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6901acf9f01c8323888dc380a56c5d4e