### PR TITLE
Add configurable text outline rendering

### DIFF
--- a/src/main/java/kamkeel/hextext/client/render/font/FontRendererBridge.java
+++ b/src/main/java/kamkeel/hextext/client/render/font/FontRendererBridge.java
@@ -36,6 +36,8 @@ public interface FontRendererBridge {
 
     int getFontHeight();
 
+    void setPos(float x, float y);
+
     void applyColorComponents(float red, float green, float blue, float alpha);
 
     void resetFormattingStyles();

--- a/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
+++ b/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
@@ -10,12 +10,16 @@ import kamkeel.hextext.client.render.TextEffectController;
 import kamkeel.hextext.client.render.TokenHighlight;
 import kamkeel.hextext.client.render.TokenHighlightUtils;
 import kamkeel.hextext.common.util.ColorCodeUtils;
+import kamkeel.hextext.common.util.ColorMath;
 import kamkeel.hextext.common.util.StringUtils;
+import kamkeel.hextext.config.HexTextConfig;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 public final class FontRendererRenderPipeline {
+
+    private static final float OUTLINE_OFFSET = 0.75f;
 
     private final FontRendererBridge bridge;
     private final ColorStateTracker colorState = new ColorStateTracker();
@@ -154,23 +158,84 @@ public final class FontRendererRenderPipeline {
 
     public float renderGlyph(char glyph, boolean italic, boolean unicode, int defaultIndex, char unicodeChar,
             GlyphRenderer glyphRenderer) {
-        float width;
         if (effects.hasActiveEffects()) {
             int targetColor = effects.computeColor(visibleGlyphIndex);
             int appliedColor = shadowPass ? ColorCodeUtils.calculateShadowColor(targetColor) : targetColor;
             setColorFromInt(appliedColor);
             effects.beforeGlyph(bridge.getFontRenderer(), glyph, visibleGlyphIndex, bridge.getPosX(), bridge.getPosY(),
                 bridge.getFontHeight());
-            width = unicode
-                ? glyphRenderer.renderUnicode(unicodeChar, italic)
-                : glyphRenderer.renderDefault(defaultIndex, italic);
+            float width = renderGlyphWithOutline(glyph, italic, unicode, defaultIndex, unicodeChar, glyphRenderer,
+                appliedColor);
             effects.afterGlyph();
-        } else {
-            width = unicode
-                ? glyphRenderer.renderUnicode(unicodeChar, italic)
-                : glyphRenderer.renderDefault(defaultIndex, italic);
+            return width;
         }
-        return width;
+
+        return renderGlyphWithOutline(glyph, italic, unicode, defaultIndex, unicodeChar, glyphRenderer,
+            bridge.getTextColor());
+    }
+
+    private float renderGlyphWithOutline(char glyph, boolean italic, boolean unicode, int defaultIndex, char unicodeChar,
+            GlyphRenderer glyphRenderer, int glyphColor) {
+        if (shouldRenderOutline(glyphColor)) {
+            renderOutline(glyph, italic, unicode, defaultIndex, unicodeChar, glyphRenderer, glyphColor);
+        }
+        return drawGlyph(glyph, italic, unicode, defaultIndex, unicodeChar, glyphRenderer);
+    }
+
+    private void renderOutline(char glyph, boolean italic, boolean unicode, int defaultIndex, char unicodeChar,
+            GlyphRenderer glyphRenderer, int glyphColor) {
+        int outlineColor = computeOutlineColor(glyphColor);
+        if ((outlineColor & 0xFFFFFF) == 0) {
+            return;
+        }
+
+        float originX = bridge.getPosX();
+        float originY = bridge.getPosY();
+        float alpha = bridge.getAlpha();
+        float red = (float) ((outlineColor >> 16) & 255) / 255.0f;
+        float green = (float) ((outlineColor >> 8) & 255) / 255.0f;
+        float blue = (float) (outlineColor & 255) / 255.0f;
+
+        bridge.applyColorComponents(red, green, blue, alpha);
+
+        for (int dx = -1; dx <= 1; dx++) {
+            for (int dy = -1; dy <= 1; dy++) {
+                if (dx == 0 && dy == 0) {
+                    continue;
+                }
+                bridge.setPos(originX + dx * OUTLINE_OFFSET, originY + dy * OUTLINE_OFFSET);
+                drawGlyph(glyph, italic, unicode, defaultIndex, unicodeChar, glyphRenderer);
+            }
+        }
+
+        bridge.setPos(originX, originY);
+        applyColorComponents(glyphColor);
+    }
+
+    private float drawGlyph(char glyph, boolean italic, boolean unicode, int defaultIndex, char unicodeChar,
+            GlyphRenderer glyphRenderer) {
+        return unicode
+            ? glyphRenderer.renderUnicode(unicodeChar, italic)
+            : glyphRenderer.renderDefault(defaultIndex, italic);
+    }
+
+    private boolean shouldRenderOutline(int glyphColor) {
+        return HexTextConfig.isTextOutlineEnabled() && !renderingShadow && (glyphColor & 0xFFFFFF) != 0;
+    }
+
+    private int computeOutlineColor(int glyphColor) {
+        int base = glyphColor & 0xFFFFFF;
+        int brightened = ColorMath.scaleBrightness(base, 1.35f);
+        int combined = ColorMath.blend(brightened, base, 0.35f);
+        return ColorMath.blend(combined, 0xFFFFFF, 0.25f);
+    }
+
+    private void applyColorComponents(int rgb) {
+        int masked = rgb & 0xFFFFFF;
+        float red = (float) ((masked >> 16) & 255) / 255.0f;
+        float green = (float) ((masked >> 8) & 255) / 255.0f;
+        float blue = (float) (masked & 255) / 255.0f;
+        bridge.applyColorComponents(red, green, blue, bridge.getAlpha());
     }
 
     public void advanceGlyphIndex() {

--- a/src/main/java/kamkeel/hextext/config/HexTextConfig.java
+++ b/src/main/java/kamkeel/hextext/config/HexTextConfig.java
@@ -10,6 +10,7 @@ import java.io.File;
 public final class HexTextConfig {
 
     public static final String CATEGORY_EFFECTS = "effects";
+    public static final String CATEGORY_RENDERING = "rendering";
 
     private static final float DEFAULT_RAINBOW_SPEED = 3000.0f;
     private static final int DEFAULT_SHAKE_INTERVAL = 100;
@@ -23,11 +24,14 @@ public final class HexTextConfig {
     private static final int MAX_IGNITE_INTERVAL = 1000;
     private static final float MAX_RAINBOW_SPEED = 5000.0f;
 
+    private static final boolean DEFAULT_TEXT_OUTLINE_ENABLED = true;
+
     private static Configuration configuration;
 
     private static float rainbowSpeed = DEFAULT_RAINBOW_SPEED;
     private static int shakeInterval = DEFAULT_SHAKE_INTERVAL;
     private static int igniteInterval = DEFAULT_IGNITE_INTERVAL;
+    private static boolean textOutlineEnabled = DEFAULT_TEXT_OUTLINE_ENABLED;
 
     private HexTextConfig() {
     }
@@ -48,6 +52,9 @@ public final class HexTextConfig {
 
         configuration.addCustomCategoryComment(CATEGORY_EFFECTS,
             "Timing controls for HexText's dynamic formatting effects.");
+
+        configuration.addCustomCategoryComment(CATEGORY_RENDERING,
+            "Rendering tweaks for HexText's font pipeline.");
 
         rainbowSpeed = clamp(configuration.getFloat(
             "rainbowCycleDurationMs",
@@ -76,6 +83,13 @@ public final class HexTextConfig {
             "Milliseconds for ignite to fade from bright to dim and back again. Lower values animate faster."
         ), MIN_IGNITE_INTERVAL, MAX_IGNITE_INTERVAL);
 
+        textOutlineEnabled = configuration.getBoolean(
+            "textOutlines",
+            CATEGORY_RENDERING,
+            DEFAULT_TEXT_OUTLINE_ENABLED,
+            "Draws an outline around every rendered glyph similar to glowing sign text."
+        );
+
         if (configuration.hasChanged()) {
             configuration.save();
         }
@@ -91,6 +105,14 @@ public final class HexTextConfig {
 
     public static int getIgniteInterval() {
         return igniteInterval;
+    }
+
+    public static boolean isTextOutlineEnabled() {
+        return textOutlineEnabled;
+    }
+
+    public static void setTextOutlineEnabled(boolean enabled) {
+        textOutlineEnabled = enabled;
     }
 
     public static Configuration getConfiguration() {

--- a/src/main/java/kamkeel/hextext/mixin/early/impl/client/MixinFontRenderer.java
+++ b/src/main/java/kamkeel/hextext/mixin/early/impl/client/MixinFontRenderer.java
@@ -205,6 +205,12 @@ public abstract class MixinFontRenderer implements FontRendererBridge {
     }
 
     @Override
+    public void setPos(float x, float y) {
+        this.posX = x;
+        this.posY = y;
+    }
+
+    @Override
     public int getFontHeight() {
         return this.FONT_HEIGHT;
     }


### PR DESCRIPTION
## Summary
- add a rendering option for glow-style text outlines and enable it by default
- extend the font rendering pipeline to draw an eight-direction outline using brightened colors
- expose font renderer position control so outline passes can offset glyph rendering safely

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_6901e0f4a97c8323ab8fdc1964ceae24