### PR TITLE
Add glow-style outline rendering for text

### DIFF
--- a/src/main/java/kamkeel/hextext/client/render/font/FontRendererBridge.java
+++ b/src/main/java/kamkeel/hextext/client/render/font/FontRendererBridge.java
@@ -34,6 +34,8 @@ public interface FontRendererBridge {
 
     float getPosY();
 
+    void setPos(float x, float y);
+
     int getFontHeight();
 
     void applyColorComponents(float red, float green, float blue, float alpha);

--- a/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
+++ b/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
@@ -11,6 +11,7 @@ import kamkeel.hextext.client.render.TokenHighlight;
 import kamkeel.hextext.client.render.TokenHighlightUtils;
 import kamkeel.hextext.common.util.ColorCodeUtils;
 import kamkeel.hextext.common.util.StringUtils;
+import kamkeel.hextext.config.HexTextConfig;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -158,6 +159,7 @@ public final class FontRendererRenderPipeline {
         if (effects.hasActiveEffects()) {
             int targetColor = effects.computeColor(visibleGlyphIndex);
             int appliedColor = shadowPass ? ColorCodeUtils.calculateShadowColor(targetColor) : targetColor;
+            renderOutlineForGlyph(glyph, italic, unicode, defaultIndex, unicodeChar, glyphRenderer, appliedColor, true);
             setColorFromInt(appliedColor);
             effects.beforeGlyph(bridge.getFontRenderer(), glyph, visibleGlyphIndex, bridge.getPosX(), bridge.getPosY(),
                 bridge.getFontHeight());
@@ -166,6 +168,8 @@ public final class FontRendererRenderPipeline {
                 : glyphRenderer.renderDefault(defaultIndex, italic);
             effects.afterGlyph();
         } else {
+            int currentColor = bridge.getTextColor();
+            renderOutlineForGlyph(glyph, italic, unicode, defaultIndex, unicodeChar, glyphRenderer, currentColor, false);
             width = unicode
                 ? glyphRenderer.renderUnicode(unicodeChar, italic)
                 : glyphRenderer.renderDefault(defaultIndex, italic);
@@ -175,6 +179,58 @@ public final class FontRendererRenderPipeline {
 
     public void advanceGlyphIndex() {
         visibleGlyphIndex++;
+    }
+
+    private void renderOutlineForGlyph(char glyph, boolean italic, boolean unicode, int defaultIndex, char unicodeChar,
+            GlyphRenderer glyphRenderer, int baseColor, boolean applyEffects) {
+        if (!shouldRenderOutline() || glyph == 0 || glyph == ' ') {
+            return;
+        }
+
+        int maskedBase = baseColor & 0xFFFFFF;
+        int outlineColor = ColorCodeUtils.calculateOutlineColor(maskedBase);
+        float baseX = bridge.getPosX();
+        float baseY = bridge.getPosY();
+        float alpha = bridge.getAlpha();
+        float baseRed = extractColorComponent(maskedBase, 16);
+        float baseGreen = extractColorComponent(maskedBase, 8);
+        float baseBlue = extractColorComponent(maskedBase, 0);
+        float outlineRed = extractColorComponent(outlineColor, 16);
+        float outlineGreen = extractColorComponent(outlineColor, 8);
+        float outlineBlue = extractColorComponent(outlineColor, 0);
+
+        for (int offsetX = -1; offsetX <= 1; offsetX++) {
+            for (int offsetY = -1; offsetY <= 1; offsetY++) {
+                if (offsetX == 0 && offsetY == 0) {
+                    continue;
+                }
+                bridge.setPos(baseX + offsetX, baseY + offsetY);
+                bridge.applyColorComponents(outlineRed, outlineGreen, outlineBlue, alpha);
+                if (applyEffects) {
+                    effects.beforeGlyph(bridge.getFontRenderer(), glyph, visibleGlyphIndex, bridge.getPosX(), bridge.getPosY(),
+                        bridge.getFontHeight());
+                }
+                if (unicode) {
+                    glyphRenderer.renderUnicode(unicodeChar, italic);
+                } else {
+                    glyphRenderer.renderDefault(defaultIndex, italic);
+                }
+                if (applyEffects) {
+                    effects.afterGlyph();
+                }
+            }
+        }
+
+        bridge.setPos(baseX, baseY);
+        bridge.applyColorComponents(baseRed, baseGreen, baseBlue, alpha);
+    }
+
+    private boolean shouldRenderOutline() {
+        return HexTextConfig.isGlowingTextOutlineEnabled() && !renderingShadow;
+    }
+
+    private static float extractColorComponent(int color, int shift) {
+        return ((color >> shift) & 0xFF) / 255.0f;
     }
 
     private void executeInstruction(RenderInstruction instruction) {

--- a/src/main/java/kamkeel/hextext/common/util/ColorCodeUtils.java
+++ b/src/main/java/kamkeel/hextext/common/util/ColorCodeUtils.java
@@ -142,6 +142,25 @@ public final class ColorCodeUtils {
         return (rgb & 0xFCFCFC) >> 2;
     }
 
+    public static int calculateOutlineColor(int rgb) {
+        int red = (rgb >> 16) & 0xFF;
+        int green = (rgb >> 8) & 0xFF;
+        int blue = rgb & 0xFF;
+
+        double luminance = red * 0.299 + green * 0.587 + blue * 0.114;
+        int outline = luminance >= 128.0 ? 0x000000 : 0xFFFFFF;
+
+        if (outline == (rgb & 0xFFFFFF)) {
+            if (outline == 0x000000) {
+                outline = 0x141414;
+            } else {
+                outline = 0xE0E0E0;
+            }
+        }
+
+        return outline;
+    }
+
     public static int hsvToRgb(float hue, float saturation, float value) {
         hue = hue % 360.0f;
         if (hue < 0) {

--- a/src/main/java/kamkeel/hextext/config/HexTextConfig.java
+++ b/src/main/java/kamkeel/hextext/config/HexTextConfig.java
@@ -10,10 +10,12 @@ import java.io.File;
 public final class HexTextConfig {
 
     public static final String CATEGORY_EFFECTS = "effects";
+    public static final String CATEGORY_RENDERING = "rendering";
 
     private static final float DEFAULT_RAINBOW_SPEED = 3000.0f;
     private static final int DEFAULT_SHAKE_INTERVAL = 100;
     private static final int DEFAULT_IGNITE_INTERVAL = 100;
+    private static final boolean DEFAULT_GLOWING_TEXT_OUTLINE = true;
 
     private static final float MIN_RAINBOW_SPEED = 1.0f;
     private static final int MIN_SHAKE_INTERVAL = 1;
@@ -28,6 +30,7 @@ public final class HexTextConfig {
     private static float rainbowSpeed = DEFAULT_RAINBOW_SPEED;
     private static int shakeInterval = DEFAULT_SHAKE_INTERVAL;
     private static int igniteInterval = DEFAULT_IGNITE_INTERVAL;
+    private static boolean glowingTextOutlineEnabled = DEFAULT_GLOWING_TEXT_OUTLINE;
 
     private HexTextConfig() {
     }
@@ -48,6 +51,8 @@ public final class HexTextConfig {
 
         configuration.addCustomCategoryComment(CATEGORY_EFFECTS,
             "Timing controls for HexText's dynamic formatting effects.");
+        configuration.addCustomCategoryComment(CATEGORY_RENDERING,
+            "Rendering options for HexText's text enhancements.");
 
         rainbowSpeed = clamp(configuration.getFloat(
             "rainbowCycleDurationMs",
@@ -76,6 +81,13 @@ public final class HexTextConfig {
             "Milliseconds for ignite to fade from bright to dim and back again. Lower values animate faster."
         ), MIN_IGNITE_INTERVAL, MAX_IGNITE_INTERVAL);
 
+        glowingTextOutlineEnabled = configuration.getBoolean(
+            "enableGlowingTextOutline",
+            CATEGORY_RENDERING,
+            DEFAULT_GLOWING_TEXT_OUTLINE,
+            "When true, HexText renders text with an outline similar to Minecraft 1.17's glow effect."
+        );
+
         if (configuration.hasChanged()) {
             configuration.save();
         }
@@ -91,6 +103,10 @@ public final class HexTextConfig {
 
     public static int getIgniteInterval() {
         return igniteInterval;
+    }
+
+    public static boolean isGlowingTextOutlineEnabled() {
+        return glowingTextOutlineEnabled;
     }
 
     public static Configuration getConfiguration() {

--- a/src/main/java/kamkeel/hextext/mixin/early/impl/client/MixinFontRenderer.java
+++ b/src/main/java/kamkeel/hextext/mixin/early/impl/client/MixinFontRenderer.java
@@ -205,6 +205,12 @@ public abstract class MixinFontRenderer implements FontRendererBridge {
     }
 
     @Override
+    public void setPos(float x, float y) {
+        this.posX = x;
+        this.posY = y;
+    }
+
+    @Override
     public int getFontHeight() {
         return this.FONT_HEIGHT;
     }


### PR DESCRIPTION
## Summary
- render every glyph with an outline inspired by Minecraft 1.17's glow ink effect
- add a configuration toggle and outline color utility helpers
- expose font renderer position control needed for drawing offset passes

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_6901e0f4a97c8323ab8fdc1964ceae24