### PR TITLE
Fix glyph outline color handling and index skipping

### DIFF
--- a/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
+++ b/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
@@ -30,6 +30,7 @@ public final class FontRendererRenderPipeline {
     private boolean renderingShadow;
     private int rawTokenSkip;
     private int visibleGlyphIndex;
+    private int outlineIncrementsToSkip;
     private int pendingRenderColor;
     private boolean hasPendingRenderColor;
 
@@ -65,6 +66,7 @@ public final class FontRendererRenderPipeline {
 
         rawTokenSkip = 0;
         visibleGlyphIndex = 0;
+        outlineIncrementsToSkip = 0;
     }
 
     public String adjustRenderText(String text) {
@@ -172,6 +174,10 @@ public final class FontRendererRenderPipeline {
     }
 
     public void advanceGlyphIndex() {
+        if (outlineIncrementsToSkip > 0) {
+            outlineIncrementsToSkip--;
+            return;
+        }
         visibleGlyphIndex++;
     }
 
@@ -187,7 +193,9 @@ public final class FontRendererRenderPipeline {
             char unicodeChar, GlyphRenderer glyphRenderer) {
         int outlineColor = resolveOutlineColor(baseColor);
         applyTemporaryColor(outlineColor);
-        for (float[] offset : GlowingTextRenderer.getOutlineOffsets()) {
+        float[][] outlineOffsets = GlowingTextRenderer.getOutlineOffsets();
+        outlineIncrementsToSkip += outlineOffsets.length;
+        for (float[] offset : outlineOffsets) {
             GL11.glPushMatrix();
             GL11.glTranslatef(offset[0], offset[1], 0.0f);
             renderGlyphInternal(unicode, defaultIndex, unicodeChar, italic, glyphRenderer);

--- a/src/main/java/kamkeel/hextext/client/render/font/GlowingTextRenderer.java
+++ b/src/main/java/kamkeel/hextext/client/render/font/GlowingTextRenderer.java
@@ -39,10 +39,21 @@ public final class GlowingTextRenderer {
     }
 
     public static int computeOutlineColor(int baseColor) {
-        int darkened = ColorMath.scaleBrightness(baseColor, OUTLINE_DARKEN_FACTOR);
-        if ((darkened & 0xFFFFFF) == 0 && (baseColor & 0xFFFFFF) != 0) {
-            return ColorMath.scaleBrightness(baseColor, OUTLINE_RECOVERY_FACTOR);
+        int maskedBase = baseColor & 0xFFFFFF;
+        if (maskedBase == 0) {
+            return 0xFFFFFF;
         }
+
+        int darkened = ColorMath.scaleBrightness(maskedBase, OUTLINE_DARKEN_FACTOR);
+        if ((darkened & 0xFFFFFF) != 0) {
+            return darkened;
+        }
+
+        int recovered = ColorMath.scaleBrightness(maskedBase, OUTLINE_RECOVERY_FACTOR);
+        if ((recovered & 0xFFFFFF) != 0) {
+            return recovered;
+        }
+
         return darkened;
     }
 }


### PR DESCRIPTION
## Summary
- ensure outline rendering only advances the visible glyph index once per character by skipping mixin increments during outline passes
- adjust outline color calculation so black text gains a white outline and other colors are darkened similar to vanilla

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_69025dd286888323bde89e52a5d8b5f0