### PR TITLE
Fix outline colors and bold overlay rendering

### DIFF
--- a/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
+++ b/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
@@ -156,7 +156,7 @@ public final class FontRendererRenderPipeline {
     }
 
     public float renderGlyph(char glyph, boolean italic, boolean unicode, int defaultIndex, char unicodeChar,
-            GlyphRenderer glyphRenderer) {
+            GlyphRenderer glyphRenderer, boolean allowOutline) {
         int baseColor = bridge.getTextColor();
         if (effects.hasActiveEffects()) {
             int targetColor = effects.computeColor(visibleGlyphIndex);
@@ -164,11 +164,12 @@ public final class FontRendererRenderPipeline {
             setColorFromInt(appliedColor);
             effects.beforeGlyph(bridge.getFontRenderer(), glyph, visibleGlyphIndex, bridge.getPosX(), bridge.getPosY(),
                 bridge.getFontHeight());
-            float width = renderGlyphWithColor(appliedColor, italic, unicode, defaultIndex, unicodeChar, glyphRenderer);
+            float width = renderGlyphWithColor(appliedColor, italic, unicode, defaultIndex, unicodeChar, glyphRenderer,
+                allowOutline);
             effects.afterGlyph();
             return width;
         }
-        return renderGlyphWithColor(baseColor, italic, unicode, defaultIndex, unicodeChar, glyphRenderer);
+        return renderGlyphWithColor(baseColor, italic, unicode, defaultIndex, unicodeChar, glyphRenderer, allowOutline);
     }
 
     public void advanceGlyphIndex() {
@@ -176,8 +177,8 @@ public final class FontRendererRenderPipeline {
     }
 
     private float renderGlyphWithColor(int color, boolean italic, boolean unicode, int defaultIndex, char unicodeChar,
-            GlyphRenderer glyphRenderer) {
-        if (!renderingShadow && GlowingTextRenderer.isOutlineEnabled()) {
+            GlyphRenderer glyphRenderer, boolean allowOutline) {
+        if (!renderingShadow && GlowingTextRenderer.isOutlineEnabled() && allowOutline) {
             return renderGlyphWithOutline(color, italic, unicode, defaultIndex, unicodeChar, glyphRenderer);
         }
         return renderGlyphInternal(unicode, defaultIndex, unicodeChar, italic, glyphRenderer);

--- a/src/main/java/kamkeel/hextext/client/render/font/GlowingTextRenderer.java
+++ b/src/main/java/kamkeel/hextext/client/render/font/GlowingTextRenderer.java
@@ -39,8 +39,12 @@ public final class GlowingTextRenderer {
     }
 
     public static int computeOutlineColor(int baseColor) {
+        if ((baseColor & 0xFFFFFF) == 0) {
+            return 0xFFFFFF;
+        }
+
         int darkened = ColorMath.scaleBrightness(baseColor, OUTLINE_DARKEN_FACTOR);
-        if ((darkened & 0xFFFFFF) == 0 && (baseColor & 0xFFFFFF) != 0) {
+        if ((darkened & 0xFFFFFF) == 0) {
             return ColorMath.scaleBrightness(baseColor, OUTLINE_RECOVERY_FACTOR);
         }
         return darkened;

--- a/src/main/java/kamkeel/hextext/mixin/early/impl/client/MixinFontRenderer.java
+++ b/src/main/java/kamkeel/hextext/mixin/early/impl/client/MixinFontRenderer.java
@@ -112,16 +112,32 @@ public abstract class MixinFontRenderer implements FontRendererBridge {
         cir.setReturnValue(StringUtils.extractFormatFromString(text));
     }
 
-    @Redirect(method = "renderCharAtPos", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;renderDefaultChar(IZ)F"))
+    @Redirect(method = "renderCharAtPos", at = @At(value = "INVOKE",
+        target = "Lnet/minecraft/client/gui/FontRenderer;renderDefaultChar(IZ)F"), ordinal = 0)
     private float hextext$renderDefaultChar(FontRenderer fontRenderer, int character, boolean italic,
             int glyphIndex, char glyph, boolean italicFlag) {
-        return hextext$pipeline.renderGlyph(glyph, italic, false, character, glyph, hextext$glyphRenderer);
+        return hextext$pipeline.renderGlyph(glyph, italic, false, character, glyph, hextext$glyphRenderer, true);
     }
 
-    @Redirect(method = "renderCharAtPos", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;renderUnicodeChar(CZ)F"))
+    @Redirect(method = "renderCharAtPos", at = @At(value = "INVOKE",
+        target = "Lnet/minecraft/client/gui/FontRenderer;renderDefaultChar(IZ)F"), ordinal = 1)
+    private float hextext$renderBoldDefaultOverlay(FontRenderer fontRenderer, int character, boolean italic,
+            int glyphIndex, char glyph, boolean italicFlag) {
+        return hextext$pipeline.renderGlyph(glyph, italic, false, character, glyph, hextext$glyphRenderer, false);
+    }
+
+    @Redirect(method = "renderCharAtPos", at = @At(value = "INVOKE",
+        target = "Lnet/minecraft/client/gui/FontRenderer;renderUnicodeChar(CZ)F"), ordinal = 0)
     private float hextext$renderUnicodeChar(FontRenderer fontRenderer, char character, boolean italic,
             int glyphIndex, char glyph, boolean italicFlag) {
-        return hextext$pipeline.renderGlyph(glyph, italic, true, 0, character, hextext$glyphRenderer);
+        return hextext$pipeline.renderGlyph(glyph, italic, true, 0, character, hextext$glyphRenderer, true);
+    }
+
+    @Redirect(method = "renderCharAtPos", at = @At(value = "INVOKE",
+        target = "Lnet/minecraft/client/gui/FontRenderer;renderUnicodeChar(CZ)F"), ordinal = 1)
+    private float hextext$renderBoldUnicodeOverlay(FontRenderer fontRenderer, char character, boolean italic,
+            int glyphIndex, char glyph, boolean italicFlag) {
+        return hextext$pipeline.renderGlyph(glyph, italic, true, 0, character, hextext$glyphRenderer, false);
     }
 
     @Inject(method = "doDraw", at = @At("TAIL"), remap = false)


### PR DESCRIPTION
## Summary
- return a white outline when the base text color is black while keeping the existing darkening fallback for other colors
- avoid drawing outlines during the extra bold overlay pass so the fill appears bold instead of only the outline
- thread an outline toggle through the glyph rendering pipeline to control when the outline is emitted

## Testing
- ./gradlew compileJava *(fails: CONNECT refused by proxy: HTTP/1.1 502 Bad Gateway)*

------
https://chatgpt.com/codex/tasks/task_e_69026568f12083239c566c5aa91bc4e0