### PR TITLE
Fix outline contrast and bold glyph rendering

### DIFF
--- a/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
+++ b/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
@@ -157,18 +157,30 @@ public final class FontRendererRenderPipeline {
 
     public float renderGlyph(char glyph, boolean italic, boolean unicode, int defaultIndex, char unicodeChar,
             GlyphRenderer glyphRenderer) {
+        return renderGlyph(glyph, italic, unicode, defaultIndex, unicodeChar, glyphRenderer, false);
+    }
+
+    public float renderGlyphBoldDuplicate(char glyph, boolean italic, boolean unicode, int defaultIndex,
+            char unicodeChar, GlyphRenderer glyphRenderer) {
+        return renderGlyph(glyph, italic, unicode, defaultIndex, unicodeChar, glyphRenderer, true);
+    }
+
+    private float renderGlyph(char glyph, boolean italic, boolean unicode, int defaultIndex, char unicodeChar,
+            GlyphRenderer glyphRenderer, boolean boldDuplicate) {
         int baseColor = bridge.getTextColor();
-        if (effects.hasActiveEffects()) {
+        if (!boldDuplicate && effects.hasActiveEffects()) {
             int targetColor = effects.computeColor(visibleGlyphIndex);
             int appliedColor = shadowPass ? ColorCodeUtils.calculateShadowColor(targetColor) : targetColor;
             setColorFromInt(appliedColor);
             effects.beforeGlyph(bridge.getFontRenderer(), glyph, visibleGlyphIndex, bridge.getPosX(), bridge.getPosY(),
                 bridge.getFontHeight());
-            float width = renderGlyphWithColor(appliedColor, italic, unicode, defaultIndex, unicodeChar, glyphRenderer);
+            float width = renderGlyphWithColor(appliedColor, italic, unicode, defaultIndex, unicodeChar, glyphRenderer,
+                false);
             effects.afterGlyph();
             return width;
         }
-        return renderGlyphWithColor(baseColor, italic, unicode, defaultIndex, unicodeChar, glyphRenderer);
+        return renderGlyphWithColor(baseColor, italic, unicode, defaultIndex, unicodeChar, glyphRenderer,
+            boldDuplicate);
     }
 
     public void advanceGlyphIndex() {
@@ -176,11 +188,12 @@ public final class FontRendererRenderPipeline {
     }
 
     private float renderGlyphWithColor(int color, boolean italic, boolean unicode, int defaultIndex, char unicodeChar,
-            GlyphRenderer glyphRenderer) {
-        if (!renderingShadow && GlowingTextRenderer.isOutlineEnabled()) {
+            GlyphRenderer glyphRenderer, boolean skipOutline) {
+        if (!renderingShadow && GlowingTextRenderer.isOutlineEnabled() && !skipOutline) {
             return renderGlyphWithOutline(color, italic, unicode, defaultIndex, unicodeChar, glyphRenderer);
         }
-        return renderGlyphInternal(unicode, defaultIndex, unicodeChar, italic, glyphRenderer);
+        applyTemporaryColor(color);
+        return renderGlyphDirect(unicode, defaultIndex, unicodeChar, italic, glyphRenderer);
     }
 
     private float renderGlyphWithOutline(int baseColor, boolean italic, boolean unicode, int defaultIndex,
@@ -190,15 +203,16 @@ public final class FontRendererRenderPipeline {
         for (float[] offset : GlowingTextRenderer.getOutlineOffsets()) {
             GL11.glPushMatrix();
             GL11.glTranslatef(offset[0], offset[1], 0.0f);
-            renderGlyphInternal(unicode, defaultIndex, unicodeChar, italic, glyphRenderer);
+            renderGlyphDirect(unicode, defaultIndex, unicodeChar, italic, glyphRenderer);
             GL11.glPopMatrix();
         }
 
         applyTemporaryColor(baseColor);
-        return renderGlyphInternal(unicode, defaultIndex, unicodeChar, italic, glyphRenderer);
+        float width = renderGlyphDirect(unicode, defaultIndex, unicodeChar, italic, glyphRenderer);
+        return width;
     }
 
-    private float renderGlyphInternal(boolean unicode, int defaultIndex, char unicodeChar, boolean italic,
+    private float renderGlyphDirect(boolean unicode, int defaultIndex, char unicodeChar, boolean italic,
             GlyphRenderer glyphRenderer) {
         return unicode
             ? glyphRenderer.renderUnicode(unicodeChar, italic)

--- a/src/main/java/kamkeel/hextext/client/render/font/GlowingTextRenderer.java
+++ b/src/main/java/kamkeel/hextext/client/render/font/GlowingTextRenderer.java
@@ -39,8 +39,13 @@ public final class GlowingTextRenderer {
     }
 
     public static int computeOutlineColor(int baseColor) {
+        int maskedBase = baseColor & 0xFFFFFF;
+        if (maskedBase == 0) {
+            return 0xFFFFFF;
+        }
+
         int darkened = ColorMath.scaleBrightness(baseColor, OUTLINE_DARKEN_FACTOR);
-        if ((darkened & 0xFFFFFF) == 0 && (baseColor & 0xFFFFFF) != 0) {
+        if ((darkened & 0xFFFFFF) == 0) {
             return ColorMath.scaleBrightness(baseColor, OUTLINE_RECOVERY_FACTOR);
         }
         return darkened;

--- a/src/main/java/kamkeel/hextext/mixin/early/impl/client/MixinFontRenderer.java
+++ b/src/main/java/kamkeel/hextext/mixin/early/impl/client/MixinFontRenderer.java
@@ -112,16 +112,32 @@ public abstract class MixinFontRenderer implements FontRendererBridge {
         cir.setReturnValue(StringUtils.extractFormatFromString(text));
     }
 
-    @Redirect(method = "renderCharAtPos", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;renderDefaultChar(IZ)F"))
-    private float hextext$renderDefaultChar(FontRenderer fontRenderer, int character, boolean italic,
+    @Redirect(method = "renderCharAtPos", at = @At(value = "INVOKE",
+        target = "Lnet/minecraft/client/gui/FontRenderer;renderDefaultChar(IZ)F", ordinal = 0))
+    private float hextext$renderDefaultPrimary(FontRenderer fontRenderer, int character, boolean italic,
             int glyphIndex, char glyph, boolean italicFlag) {
         return hextext$pipeline.renderGlyph(glyph, italic, false, character, glyph, hextext$glyphRenderer);
     }
 
-    @Redirect(method = "renderCharAtPos", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;renderUnicodeChar(CZ)F"))
-    private float hextext$renderUnicodeChar(FontRenderer fontRenderer, char character, boolean italic,
+    @Redirect(method = "renderCharAtPos", at = @At(value = "INVOKE",
+        target = "Lnet/minecraft/client/gui/FontRenderer;renderDefaultChar(IZ)F", ordinal = 1))
+    private float hextext$renderDefaultBold(FontRenderer fontRenderer, int character, boolean italic,
+            int glyphIndex, char glyph, boolean italicFlag) {
+        return hextext$pipeline.renderGlyphBoldDuplicate(glyph, italic, false, character, glyph, hextext$glyphRenderer);
+    }
+
+    @Redirect(method = "renderCharAtPos", at = @At(value = "INVOKE",
+        target = "Lnet/minecraft/client/gui/FontRenderer;renderUnicodeChar(CZ)F", ordinal = 0))
+    private float hextext$renderUnicodePrimary(FontRenderer fontRenderer, char character, boolean italic,
             int glyphIndex, char glyph, boolean italicFlag) {
         return hextext$pipeline.renderGlyph(glyph, italic, true, 0, character, hextext$glyphRenderer);
+    }
+
+    @Redirect(method = "renderCharAtPos", at = @At(value = "INVOKE",
+        target = "Lnet/minecraft/client/gui/FontRenderer;renderUnicodeChar(CZ)F", ordinal = 1))
+    private float hextext$renderUnicodeBold(FontRenderer fontRenderer, char character, boolean italic,
+            int glyphIndex, char glyph, boolean italicFlag) {
+        return hextext$pipeline.renderGlyphBoldDuplicate(glyph, italic, true, 0, character, hextext$glyphRenderer);
     }
 
     @Inject(method = "doDraw", at = @At("TAIL"), remap = false)


### PR DESCRIPTION
## Summary
- ensure the outline falls back to white when rendering black text
- render bold duplicate passes without reapplying outlines while keeping effects intact
- adjust font renderer mixin redirects to route bold passes through the new pipeline helper

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_69026568f12083239c566c5aa91bc4e0