### PR TITLE
Fix outline color for black text

### DIFF
--- a/src/main/java/kamkeel/hextext/client/render/font/GlowingTextRenderer.java
+++ b/src/main/java/kamkeel/hextext/client/render/font/GlowingTextRenderer.java
@@ -39,9 +39,14 @@ public final class GlowingTextRenderer {
     }
 
     public static int computeOutlineColor(int baseColor) {
-        int darkened = ColorMath.scaleBrightness(baseColor, OUTLINE_DARKEN_FACTOR);
-        if ((darkened & 0xFFFFFF) == 0 && (baseColor & 0xFFFFFF) != 0) {
-            return ColorMath.scaleBrightness(baseColor, OUTLINE_RECOVERY_FACTOR);
+        int rgb = baseColor & 0xFFFFFF;
+        if (rgb == 0) {
+            return 0xFFFFFF;
+        }
+
+        int darkened = ColorMath.scaleBrightness(rgb, OUTLINE_DARKEN_FACTOR);
+        if ((darkened & 0xFFFFFF) == 0) {
+            return ColorMath.scaleBrightness(rgb, OUTLINE_RECOVERY_FACTOR);
         }
         return darkened;
     }

--- a/src/test/java/kamkeel/hextext/client/render/font/GlowingTextRendererTest.java
+++ b/src/test/java/kamkeel/hextext/client/render/font/GlowingTextRendererTest.java
@@ -1,0 +1,34 @@
+package kamkeel.hextext.client.render.font;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class GlowingTextRendererTest {
+
+    @Test
+    public void outlineTurnsBlackTextWhite() {
+        int outline = GlowingTextRenderer.computeOutlineColor(0x000000);
+        assertEquals(0xFFFFFF, outline);
+    }
+
+    @Test
+    public void outlineTreatsBlackWithAlphaAsBlack() {
+        int outline = GlowingTextRenderer.computeOutlineColor(0xFF000000);
+        assertEquals(0xFFFFFF, outline);
+    }
+
+    @Test
+    public void outlineDarkensColouredText() {
+        int baseColor = 0x3366CC;
+        int outline = GlowingTextRenderer.computeOutlineColor(baseColor);
+        assertEquals(0x142952, outline);
+    }
+
+    @Test
+    public void outlineRecoversWhenDarkeningRemovesAllColour() {
+        int baseColor = 0x010101;
+        int outline = GlowingTextRenderer.computeOutlineColor(baseColor);
+        assertEquals(0x000000, outline);
+    }
+}


### PR DESCRIPTION
## Summary
- treat black text as a special case so outlines render white instead of disappearing
- adjust the outline colour darkening logic to ignore alpha and rely on colour scaling for non-black glyphs
- add tests covering black text, alpha-masked black, and standard colour darkening

## Testing
- `./gradlew test` *(fails: HTTP/1.1 502 Bad Gateway when fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_690267e59bb48323ad0e31c6d489bddb