### PR TITLE
Fix black text outline color and ensure bold fill renders with outlines

### DIFF
--- a/src/main/java/kamkeel/hextext/client/render/font/FontRendererBridge.java
+++ b/src/main/java/kamkeel/hextext/client/render/font/FontRendererBridge.java
@@ -20,6 +20,8 @@ public interface FontRendererBridge {
 
     int getTextColor();
 
+    boolean isBoldStyle();
+
     float getAlpha();
 
     float getRedComponent();

--- a/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
+++ b/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
@@ -195,7 +195,17 @@ public final class FontRendererRenderPipeline {
         }
 
         applyTemporaryColor(baseColor);
-        return renderGlyphInternal(unicode, defaultIndex, unicodeChar, italic, glyphRenderer);
+        float width = renderGlyphInternal(unicode, defaultIndex, unicodeChar, italic, glyphRenderer);
+
+        if (bridge.isBoldStyle()) {
+            float boldOffset = unicode ? 0.5f : 1.0f;
+            GL11.glPushMatrix();
+            GL11.glTranslatef(boldOffset, 0.0f, 0.0f);
+            renderGlyphInternal(unicode, defaultIndex, unicodeChar, italic, glyphRenderer);
+            GL11.glPopMatrix();
+        }
+
+        return width;
     }
 
     private float renderGlyphInternal(boolean unicode, int defaultIndex, char unicodeChar, boolean italic,

--- a/src/main/java/kamkeel/hextext/client/render/font/GlowingTextRenderer.java
+++ b/src/main/java/kamkeel/hextext/client/render/font/GlowingTextRenderer.java
@@ -39,8 +39,12 @@ public final class GlowingTextRenderer {
     }
 
     public static int computeOutlineColor(int baseColor) {
+        if ((baseColor & 0xFFFFFF) == 0) {
+            return 0xFFFFFF;
+        }
+
         int darkened = ColorMath.scaleBrightness(baseColor, OUTLINE_DARKEN_FACTOR);
-        if ((darkened & 0xFFFFFF) == 0 && (baseColor & 0xFFFFFF) != 0) {
+        if ((darkened & 0xFFFFFF) == 0) {
             return ColorMath.scaleBrightness(baseColor, OUTLINE_RECOVERY_FACTOR);
         }
         return darkened;

--- a/src/main/java/kamkeel/hextext/mixin/early/impl/client/MixinFontRenderer.java
+++ b/src/main/java/kamkeel/hextext/mixin/early/impl/client/MixinFontRenderer.java
@@ -170,6 +170,11 @@ public abstract class MixinFontRenderer implements FontRendererBridge {
     }
 
     @Override
+    public boolean isBoldStyle() {
+        return this.boldStyle;
+    }
+
+    @Override
     public float getAlpha() {
         return this.alpha;
     }


### PR DESCRIPTION
## Summary
- return a white outline when text color is black so the glow stays visible
- expose the bold style flag through the font bridge and re-render the glyph fill with a bold offset during outline draws

## Testing
- ./gradlew test *(fails: proxy 502 while downloading Minecraft manifest)*

------
https://chatgpt.com/codex/tasks/task_e_690267e59bb48323ad0e31c6d489bddb