### PR TITLE
Fix outline color handling and bold outline rendering

### DIFF
--- a/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
+++ b/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
@@ -32,6 +32,8 @@ public final class FontRendererRenderPipeline {
     private int visibleGlyphIndex;
     private int pendingRenderColor;
     private boolean hasPendingRenderColor;
+    private int outlineGlyphIndex;
+    private boolean outlineRenderedForGlyph;
 
     public FontRendererRenderPipeline(FontRendererBridge bridge) {
         this.bridge = bridge;
@@ -65,6 +67,8 @@ public final class FontRendererRenderPipeline {
 
         rawTokenSkip = 0;
         visibleGlyphIndex = 0;
+        outlineGlyphIndex = -1;
+        outlineRenderedForGlyph = false;
     }
 
     public String adjustRenderText(String text) {
@@ -177,9 +181,12 @@ public final class FontRendererRenderPipeline {
 
     private float renderGlyphWithColor(int color, boolean italic, boolean unicode, int defaultIndex, char unicodeChar,
             GlyphRenderer glyphRenderer) {
-        if (!renderingShadow && GlowingTextRenderer.isOutlineEnabled()) {
+        if (!renderingShadow && GlowingTextRenderer.isOutlineEnabled()
+            && shouldRenderOutlineForCurrentGlyph()) {
             return renderGlyphWithOutline(color, italic, unicode, defaultIndex, unicodeChar, glyphRenderer);
         }
+
+        applyTemporaryColor(color);
         return renderGlyphInternal(unicode, defaultIndex, unicodeChar, italic, glyphRenderer);
     }
 
@@ -196,6 +203,20 @@ public final class FontRendererRenderPipeline {
 
         applyTemporaryColor(baseColor);
         return renderGlyphInternal(unicode, defaultIndex, unicodeChar, italic, glyphRenderer);
+    }
+
+    private boolean shouldRenderOutlineForCurrentGlyph() {
+        if (visibleGlyphIndex != outlineGlyphIndex) {
+            outlineGlyphIndex = visibleGlyphIndex;
+            outlineRenderedForGlyph = false;
+        }
+
+        if (!outlineRenderedForGlyph) {
+            outlineRenderedForGlyph = true;
+            return true;
+        }
+
+        return false;
     }
 
     private float renderGlyphInternal(boolean unicode, int defaultIndex, char unicodeChar, boolean italic,

--- a/src/main/java/kamkeel/hextext/client/render/font/GlowingTextRenderer.java
+++ b/src/main/java/kamkeel/hextext/client/render/font/GlowingTextRenderer.java
@@ -39,9 +39,14 @@ public final class GlowingTextRenderer {
     }
 
     public static int computeOutlineColor(int baseColor) {
-        int darkened = ColorMath.scaleBrightness(baseColor, OUTLINE_DARKEN_FACTOR);
-        if ((darkened & 0xFFFFFF) == 0 && (baseColor & 0xFFFFFF) != 0) {
-            return ColorMath.scaleBrightness(baseColor, OUTLINE_RECOVERY_FACTOR);
+        int maskedBase = baseColor & 0xFFFFFF;
+        if (maskedBase == 0) {
+            return 0xFFFFFF;
+        }
+
+        int darkened = ColorMath.scaleBrightness(maskedBase, OUTLINE_DARKEN_FACTOR);
+        if ((darkened & 0xFFFFFF) == 0) {
+            return ColorMath.scaleBrightness(maskedBase, OUTLINE_RECOVERY_FACTOR);
         }
         return darkened;
     }


### PR DESCRIPTION
## Summary
- return a white outline for black text and preserve darkened outlines for other colours
- draw outline layers once per glyph so bold renders thicken the fill instead of the outline

## Testing
- ./gradlew test *(fails: CONNECT refused by proxy: HTTP/1.1 502 Bad Gateway)*

------
https://chatgpt.com/codex/tasks/task_e_690267e59bb48323ad0e31c6d489bddb