### PR TITLE
Add sign interaction API for sign effects

### DIFF
--- a/src/main/java/kamkeel/hextext/CommonProxy.java
+++ b/src/main/java/kamkeel/hextext/CommonProxy.java
@@ -8,8 +8,9 @@ import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import kamkeel.hextext.config.HexTextConfig;
+import kamkeel.hextext.api.sign.HexTextSignInteractions;
 import kamkeel.hextext.client.config.HexTextConfigEventHandler;
+import kamkeel.hextext.config.HexTextConfig;
 
 public class CommonProxy {
     public static final Logger LOGGER = LogManager.getLogger(HexText.ID);
@@ -25,6 +26,7 @@ public class CommonProxy {
     public void preInit(FMLPreInitializationEvent ev) {
         HexTextConfig.init(ev.getSuggestedConfigurationFile());
         eventsInit();
+        HexTextSignInteractions.registerDefaults();
     }
 
     public void init(FMLInitializationEvent ev) {

--- a/src/main/java/kamkeel/hextext/api/sign/HexTextSignInteractions.java
+++ b/src/main/java/kamkeel/hextext/api/sign/HexTextSignInteractions.java
@@ -1,0 +1,192 @@
+package kamkeel.hextext.api.sign;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+
+/**
+ * Public API for configuring the items that interact with HexText signs.
+ * <p>
+ * Items can grant one or more {@link SignInteractionType} behaviours.
+ * Mods can call the registration methods during or after {@code FMLPreInitializationEvent}.
+ */
+public final class HexTextSignInteractions {
+
+    /** Metadata value that matches every sub-type of the registered item. */
+    public static final int ANY_META = OreDictionary.WILDCARD_VALUE;
+
+    private static final Map<Item, List<InteractionEntry>> REGISTRY = new IdentityHashMap<>();
+    private static volatile boolean defaultsRegistered = false;
+
+    private HexTextSignInteractions() {
+    }
+
+    /**
+     * Registers the default vanilla-style sign interactions provided by HexText.
+     * This method is automatically invoked by the mod, but exposed for completeness.
+     */
+    public static void registerDefaults() {
+        if (defaultsRegistered) {
+            return;
+        }
+        synchronized (REGISTRY) {
+            if (defaultsRegistered) {
+                return;
+            }
+            register(Items.glowstone_dust, ANY_META, EnumSet.of(SignInteractionType.GLOW));
+            register(Items.redstone, ANY_META, EnumSet.of(SignInteractionType.OUTLINE));
+            register(Items.slime_ball, ANY_META, EnumSet.of(SignInteractionType.WAX));
+            register(Items.dye, 0, EnumSet.of(SignInteractionType.CLEANSE));
+            defaultsRegistered = true;
+        }
+    }
+
+    /**
+     * Registers the supplied item stack for the provided interactions.
+     *
+     * @param stack        the representative item stack
+     * @param interactions the interactions to register
+     */
+    public static void register(ItemStack stack, SignInteractionType... interactions) {
+        if (stack == null || stack.getItem() == null) {
+            return;
+        }
+        register(stack.getItem(), stack.getItemDamage(), toEnumSet(interactions));
+    }
+
+    /**
+     * Registers the supplied item for the provided interactions.
+     *
+     * @param item         the item to register
+     * @param metadata     the metadata or {@link #ANY_META}
+     * @param interactions the interactions to register
+     */
+    public static void register(Item item, int metadata, Set<SignInteractionType> interactions) {
+        if (item == null || interactions == null || interactions.isEmpty()) {
+            return;
+        }
+        EnumSet<SignInteractionType> copy = EnumSet.copyOf(interactions);
+        synchronized (REGISTRY) {
+            List<InteractionEntry> entries = REGISTRY.computeIfAbsent(item, ignored -> new ArrayList<>());
+            InteractionEntry entry = findEntry(entries, metadata);
+            if (entry == null) {
+                entry = new InteractionEntry(metadata, copy);
+                entries.add(entry);
+            } else {
+                entry.interactions.addAll(copy);
+            }
+        }
+    }
+
+    /**
+     * Removes the given interactions for the supplied item metadata combination.
+     *
+     * @param item         the item to modify
+     * @param metadata     the metadata or {@link #ANY_META}
+     * @param interactions the interactions to remove
+     */
+    public static void unregister(Item item, int metadata, SignInteractionType... interactions) {
+        if (item == null || interactions == null || interactions.length == 0) {
+            return;
+        }
+        EnumSet<SignInteractionType> removal = toEnumSet(interactions);
+        synchronized (REGISTRY) {
+            List<InteractionEntry> entries = REGISTRY.get(item);
+            if (entries == null) {
+                return;
+            }
+            InteractionEntry entry = findEntry(entries, metadata);
+            if (entry == null) {
+                return;
+            }
+            entry.interactions.removeAll(removal);
+            if (entry.interactions.isEmpty()) {
+                entries.remove(entry);
+                if (entries.isEmpty()) {
+                    REGISTRY.remove(item);
+                }
+            }
+        }
+    }
+
+    /**
+     * Determines whether the supplied stack grants the requested interaction.
+     *
+     * @param stack the item stack to inspect
+     * @param type  the interaction type
+     * @return {@code true} when the stack grants the interaction
+     */
+    public static boolean provides(ItemStack stack, SignInteractionType type) {
+        if (stack == null || type == null) {
+            return false;
+        }
+        return getInteractions(stack).contains(type);
+    }
+
+    /**
+     * Returns the interactions provided by the supplied stack.
+     *
+     * @param stack the stack to inspect
+     * @return an immutable set of interactions
+     */
+    public static Set<SignInteractionType> getInteractions(ItemStack stack) {
+        if (stack == null || stack.getItem() == null) {
+            return Collections.emptySet();
+        }
+        EnumSet<SignInteractionType> result = EnumSet.noneOf(SignInteractionType.class);
+        Item item = stack.getItem();
+        int metadata = stack.getItemDamage();
+        synchronized (REGISTRY) {
+            List<InteractionEntry> entries = REGISTRY.get(item);
+            if (entries == null) {
+                return Collections.emptySet();
+            }
+            for (InteractionEntry entry : entries) {
+                if (entry.matches(metadata)) {
+                    result.addAll(entry.interactions);
+                }
+            }
+        }
+        return result.isEmpty() ? Collections.emptySet() : Collections.unmodifiableSet(result);
+    }
+
+    private static InteractionEntry findEntry(List<InteractionEntry> entries, int metadata) {
+        for (InteractionEntry entry : entries) {
+            if (entry.metadata == metadata) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    private static EnumSet<SignInteractionType> toEnumSet(SignInteractionType... interactions) {
+        EnumSet<SignInteractionType> set = EnumSet.noneOf(SignInteractionType.class);
+        if (interactions != null) {
+            Collections.addAll(set, interactions);
+        }
+        return set;
+    }
+
+    private static final class InteractionEntry {
+        private final int metadata;
+        private final EnumSet<SignInteractionType> interactions;
+
+        private InteractionEntry(int metadata, EnumSet<SignInteractionType> interactions) {
+            this.metadata = metadata;
+            this.interactions = interactions;
+        }
+
+        private boolean matches(int stackMeta) {
+            return metadata == ANY_META || metadata == stackMeta;
+        }
+    }
+}

--- a/src/main/java/kamkeel/hextext/api/sign/SignInteractionType.java
+++ b/src/main/java/kamkeel/hextext/api/sign/SignInteractionType.java
@@ -1,0 +1,16 @@
+package kamkeel.hextext.api.sign;
+
+/**
+ * The different interactions that can be performed on a HexText sign
+ * using an item. An item may provide multiple interactions at once.
+ */
+public enum SignInteractionType {
+    /** Applies wax to the sign, preventing further edits. */
+    WAX,
+    /** Enables the glowing text effect for the interacted side. */
+    GLOW,
+    /** Enables the text outline effect for the interacted side. */
+    OUTLINE,
+    /** Removes side-specific effects such as glow and outline. */
+    CLEANSE
+}

--- a/src/main/java/kamkeel/hextext/common/sign/SignState.java
+++ b/src/main/java/kamkeel/hextext/common/sign/SignState.java
@@ -23,6 +23,10 @@ public interface SignState {
 
     boolean hextext$setGlowing(SignSide side, boolean glowing);
 
+    boolean hextext$isOutlined(SignSide side);
+
+    boolean hextext$setOutlined(SignSide side, boolean outlined);
+
     String[] hextext$getLines(SignSide side);
 
     default String hextext$getLine(SignSide side, int index) {

--- a/src/main/java/kamkeel/hextext/common/sign/SignSyncPacket.java
+++ b/src/main/java/kamkeel/hextext/common/sign/SignSyncPacket.java
@@ -10,6 +10,10 @@ public interface SignSyncPacket {
 
     boolean hextext$isGlowing(SignSide side);
 
+    void hextext$setOutlined(SignSide side, boolean outlined);
+
+    boolean hextext$isOutlined(SignSide side);
+
     void hextext$setWaxed(boolean waxed);
 
     boolean hextext$isWaxed();

--- a/src/main/java/kamkeel/hextext/mixin/early/impl/MixinBlockSign.java
+++ b/src/main/java/kamkeel/hextext/mixin/early/impl/MixinBlockSign.java
@@ -1,5 +1,7 @@
 package kamkeel.hextext.mixin.early.impl;
 
+import kamkeel.hextext.api.sign.HexTextSignInteractions;
+import kamkeel.hextext.api.sign.SignInteractionType;
 import kamkeel.hextext.common.sign.SignSide;
 import kamkeel.hextext.common.sign.SignSideHelper;
 import kamkeel.hextext.common.sign.SignState;
@@ -7,7 +9,6 @@ import net.minecraft.block.BlockContainer;
 import net.minecraft.block.BlockSign;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntitySign;
@@ -17,6 +18,9 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Set;
+
 
 @Mixin(BlockSign.class)
 public abstract class MixinBlockSign extends BlockContainer {
@@ -49,30 +53,60 @@ public abstract class MixinBlockSign extends BlockContainer {
         ItemStack stack = player.getCurrentEquippedItem();
 
         if (stack != null) {
-            if (worldIn.isRemote) {
-                return true;
-            }
-
-            if (stack.getItem() == Items.glowstone_dust) {
-                if (signState.hextext$setGlowing(clickedSide, true)) {
-                    hextext$consumeItem(player, stack);
-                    worldIn.markBlockForUpdate(x, y, z);
+            Set<SignInteractionType> interactions = HexTextSignInteractions.getInteractions(stack);
+            if (!interactions.isEmpty()) {
+                if (worldIn.isRemote) {
+                    return true;
                 }
-                return true;
-            }
 
-            if (stack.getItem() == Items.dye && stack.getItemDamage() == 0) {
-                if (signState.hextext$setGlowing(clickedSide, false)) {
-                    hextext$consumeItem(player, stack);
-                    worldIn.markBlockForUpdate(x, y, z);
+                boolean consumed = false;
+                boolean updated = false;
+
+                if (interactions.contains(SignInteractionType.CLEANSE)) {
+                    boolean changed = false;
+                    changed |= signState.hextext$setGlowing(clickedSide, false);
+                    changed |= signState.hextext$setOutlined(clickedSide, false);
+                    if (changed) {
+                        updated = true;
+                        if (!consumed) {
+                            hextext$consumeItem(player, stack);
+                            consumed = true;
+                        }
+                    }
                 }
-                return true;
-            }
 
-            if (stack.getItem() == Items.slime_ball) {
-                if (!signState.hextext$isWaxed()) {
+                if (interactions.contains(SignInteractionType.WAX) && !signState.hextext$isWaxed()) {
                     signState.hextext$setWaxed(true);
-                    hextext$consumeItem(player, stack);
+                    updated = true;
+                    if (!consumed) {
+                        hextext$consumeItem(player, stack);
+                        consumed = true;
+                    }
+                }
+
+                if (interactions.contains(SignInteractionType.GLOW)) {
+                    boolean changed = signState.hextext$setGlowing(clickedSide, true);
+                    if (changed) {
+                        updated = true;
+                        if (!consumed) {
+                            hextext$consumeItem(player, stack);
+                            consumed = true;
+                        }
+                    }
+                }
+
+                if (interactions.contains(SignInteractionType.OUTLINE)) {
+                    boolean changed = signState.hextext$setOutlined(clickedSide, true);
+                    if (changed) {
+                        updated = true;
+                        if (!consumed) {
+                            hextext$consumeItem(player, stack);
+                            consumed = true;
+                        }
+                    }
+                }
+
+                if (updated) {
                     worldIn.markBlockForUpdate(x, y, z);
                 }
                 return true;

--- a/src/main/java/kamkeel/hextext/mixin/early/impl/MixinS33PacketUpdateSign.java
+++ b/src/main/java/kamkeel/hextext/mixin/early/impl/MixinS33PacketUpdateSign.java
@@ -31,6 +31,12 @@ public abstract class MixinS33PacketUpdateSign extends Packet implements SignSyn
     private boolean hextext$glowBack;
 
     @Unique
+    private boolean hextext$outlineFront;
+
+    @Unique
+    private boolean hextext$outlineBack;
+
+    @Unique
     private boolean hextext$waxed;
 
     @Inject(method = "writePacketData", at = @At("TAIL"))
@@ -44,6 +50,8 @@ public abstract class MixinS33PacketUpdateSign extends Packet implements SignSyn
         }
         data.writeBoolean(hextext$glowFront);
         data.writeBoolean(hextext$glowBack);
+        data.writeBoolean(hextext$outlineFront);
+        data.writeBoolean(hextext$outlineBack);
         data.writeBoolean(hextext$waxed);
     }
 
@@ -59,6 +67,8 @@ public abstract class MixinS33PacketUpdateSign extends Packet implements SignSyn
         }
         hextext$glowFront = data.readBoolean();
         hextext$glowBack = data.readBoolean();
+        hextext$outlineFront = data.readBoolean();
+        hextext$outlineBack = data.readBoolean();
         hextext$waxed = data.readBoolean();
     }
 
@@ -88,6 +98,20 @@ public abstract class MixinS33PacketUpdateSign extends Packet implements SignSyn
     @Override
     public boolean hextext$isGlowing(SignSide side) {
         return side == SignSide.FRONT ? hextext$glowFront : hextext$glowBack;
+    }
+
+    @Override
+    public void hextext$setOutlined(SignSide side, boolean outlined) {
+        if (side == SignSide.FRONT) {
+            hextext$outlineFront = outlined;
+        } else {
+            hextext$outlineBack = outlined;
+        }
+    }
+
+    @Override
+    public boolean hextext$isOutlined(SignSide side) {
+        return side == SignSide.FRONT ? hextext$outlineFront : hextext$outlineBack;
     }
 
     @Override

--- a/src/main/java/kamkeel/hextext/mixin/early/impl/MixinTileEntitySign.java
+++ b/src/main/java/kamkeel/hextext/mixin/early/impl/MixinTileEntitySign.java
@@ -30,6 +30,9 @@ public abstract class MixinTileEntitySign extends TileEntity implements SignStat
     private final boolean[] hextext$glowStates = new boolean[SignSide.values().length];
 
     @Unique
+    private final boolean[] hextext$outlineStates = new boolean[SignSide.values().length];
+
+    @Unique
     private final String[] hextext$backSignText = new String[] {"", "", "", ""};
 
     @Unique
@@ -46,6 +49,8 @@ public abstract class MixinTileEntitySign extends TileEntity implements SignStat
         hextext$isWaxed = compound.getBoolean("HexTextWaxed");
         hextext$glowStates[SignSide.FRONT.ordinal()] = compound.getBoolean("HexTextGlowFront");
         hextext$glowStates[SignSide.BACK.ordinal()] = compound.getBoolean("HexTextGlowBack");
+        hextext$outlineStates[SignSide.FRONT.ordinal()] = compound.getBoolean("HexTextOutlineFront");
+        hextext$outlineStates[SignSide.BACK.ordinal()] = compound.getBoolean("HexTextOutlineBack");
         if (compound.hasKey("HexTextBackText0")) {
             for (int i = 0; i < hextext$backSignText.length; i++) {
                 hextext$backSignText[i] = compound.getString("HexTextBackText" + i);
@@ -59,6 +64,8 @@ public abstract class MixinTileEntitySign extends TileEntity implements SignStat
         compound.setBoolean("HexTextWaxed", hextext$isWaxed);
         compound.setBoolean("HexTextGlowFront", hextext$glowStates[SignSide.FRONT.ordinal()]);
         compound.setBoolean("HexTextGlowBack", hextext$glowStates[SignSide.BACK.ordinal()]);
+        compound.setBoolean("HexTextOutlineFront", hextext$outlineStates[SignSide.FRONT.ordinal()]);
+        compound.setBoolean("HexTextOutlineBack", hextext$outlineStates[SignSide.BACK.ordinal()]);
         for (int i = 0; i < hextext$backSignText.length; i++) {
             compound.setString("HexTextBackText" + i, hextext$backSignText[i]);
         }
@@ -131,6 +138,22 @@ public abstract class MixinTileEntitySign extends TileEntity implements SignStat
     }
 
     @Override
+    public boolean hextext$isOutlined(SignSide side) {
+        return hextext$outlineStates[side.ordinal()];
+    }
+
+    @Override
+    public boolean hextext$setOutlined(SignSide side, boolean outlined) {
+        int index = side.ordinal();
+        boolean changed = hextext$outlineStates[index] != outlined;
+        hextext$outlineStates[index] = outlined;
+        if (changed) {
+            markDirty();
+        }
+        return changed;
+    }
+
+    @Override
     public String[] hextext$getLines(SignSide side) {
         return side == SignSide.FRONT ? signText : hextext$backSignText;
     }
@@ -144,6 +167,7 @@ public abstract class MixinTileEntitySign extends TileEntity implements SignStat
         syncPacket.hextext$setBackText(hextext$backSignText.clone());
         for (SignSide side : SignSide.values()) {
             syncPacket.hextext$setGlowing(side, hextext$glowStates[side.ordinal()]);
+            syncPacket.hextext$setOutlined(side, hextext$outlineStates[side.ordinal()]);
         }
         syncPacket.hextext$setWaxed(hextext$isWaxed);
         return packet;

--- a/src/main/java/kamkeel/hextext/mixin/early/impl/client/MixinNetHandlerPlayClient.java
+++ b/src/main/java/kamkeel/hextext/mixin/early/impl/client/MixinNetHandlerPlayClient.java
@@ -41,6 +41,8 @@ public abstract class MixinNetHandlerPlayClient {
 
         state.hextext$setGlowing(SignSide.FRONT, sync.hextext$isGlowing(SignSide.FRONT));
         state.hextext$setGlowing(SignSide.BACK, sync.hextext$isGlowing(SignSide.BACK));
+        state.hextext$setOutlined(SignSide.FRONT, sync.hextext$isOutlined(SignSide.FRONT));
+        state.hextext$setOutlined(SignSide.BACK, sync.hextext$isOutlined(SignSide.BACK));
         state.hextext$setWaxed(sync.hextext$isWaxed());
         state.hextext$setEditingSide(SignSide.FRONT);
     }

--- a/src/main/java/kamkeel/hextext/mixin/early/impl/client/MixinTileEntitySignRenderer.java
+++ b/src/main/java/kamkeel/hextext/mixin/early/impl/client/MixinTileEntitySignRenderer.java
@@ -85,11 +85,12 @@ public abstract class MixinTileEntitySignRenderer extends TileEntitySpecialRende
         GL11.glDepthMask(false);
 
         boolean glowing = state.hextext$isGlowing(side);
+        boolean outlined = state.hextext$isOutlined(side);
         boolean lightingEnabled = GL11.glIsEnabled(GL11.GL_LIGHTING);
         if (glowing && lightingEnabled) {
             GL11.glDisable(GL11.GL_LIGHTING);
         }
-        GlowingTextRenderer.setOutlineEnabled(glowing);
+        GlowingTextRenderer.setOutlineEnabled(glowing || outlined);
 
         String[] lines = state.hextext$getLines(side);
         int baseY = -lines.length * 5;


### PR DESCRIPTION
## Summary
- add a HexText sign interaction registry API with defaults for glow, outline, wax, and cleanse items
- extend sign state syncing to include outline flags and expose them through the API
- switch sign activation logic to use the registry so items can provide multiple behaviours

## Testing
- ./gradlew compileJava --stacktrace

------
https://chatgpt.com/codex/tasks/task_e_6902a9e192cc8323853da101e6500928