### PR TITLE
Fix standing sign direction calculation

### DIFF
--- a/src/main/java/kamkeel/hextext/common/sign/SignSideHelper.java
+++ b/src/main/java/kamkeel/hextext/common/sign/SignSideHelper.java
@@ -42,8 +42,9 @@ public final class SignSideHelper {
             }
         }
 
-        float wrapped = MathHelper.wrapAngleTo180_float((float) (metadata * 360) / 16.0F);
-        double radians = Math.toRadians(wrapped);
-        return new double[] {MathHelper.sin((float) radians), MathHelper.cos((float) radians)};
+        float orientation = (metadata * 360.0F) / 16.0F;
+        float yaw = MathHelper.wrapAngleTo180_float(orientation - 180.0F);
+        double radians = Math.toRadians(yaw);
+        return new double[] {-MathHelper.sin((float) radians), MathHelper.cos((float) radians)};
     }
 }


### PR DESCRIPTION
## Summary
- adjust the standing sign orientation calculation to match Minecraft's yaw metadata
- ensure the computed front normal points toward the face a player used when placing the sign

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_6902c4565d148323823dfd1562890f11