### PR TITLE
Fix standing sign side detection

### DIFF
--- a/src/main/java/kamkeel/hextext/common/sign/SignSideHelper.java
+++ b/src/main/java/kamkeel/hextext/common/sign/SignSideHelper.java
@@ -44,6 +44,11 @@ public final class SignSideHelper {
 
         float wrapped = MathHelper.wrapAngleTo180_float((float) (metadata * 360) / 16.0F);
         double radians = Math.toRadians(wrapped);
-        return new double[] {MathHelper.sin((float) radians), MathHelper.cos((float) radians)};
+        float sin = MathHelper.sin((float) radians);
+        float cos = MathHelper.cos((float) radians);
+        // Standing signs rotate the model by -rotation degrees when rendering. The front of the
+        // sign therefore points opposite the positive rotation direction. Negating the sine
+        // component aligns the computed normal with the actual facing direction of the sign.
+        return new double[] {-sin, cos};
     }
 }

--- a/src/test/java/kamkeel/hextext/common/sign/SignSideHelperTest.java
+++ b/src/test/java/kamkeel/hextext/common/sign/SignSideHelperTest.java
@@ -1,0 +1,51 @@
+package kamkeel.hextext.common.sign;
+
+import net.minecraft.block.Block;
+import net.minecraft.tileentity.TileEntitySign;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SignSideHelperTest {
+
+    @Test
+    public void standingSignSouthFacesPositiveZ() {
+        TileEntitySign sign = createSign(null, 0);
+        Assert.assertEquals(SignSide.FRONT, SignSideHelper.determineSide(sign, 0.5D, 1.5D));
+        Assert.assertEquals(SignSide.BACK, SignSideHelper.determineSide(sign, 0.5D, -0.5D));
+    }
+
+    @Test
+    public void standingSignWestFacesNegativeX() {
+        TileEntitySign sign = createSign(null, 4);
+        Assert.assertEquals(SignSide.FRONT, SignSideHelper.determineSide(sign, -0.5D, 0.5D));
+        Assert.assertEquals(SignSide.BACK, SignSideHelper.determineSide(sign, 1.5D, 0.5D));
+    }
+
+    private static TileEntitySign createSign(Block block, int metadata) {
+        return new TestTileEntitySign(block, metadata);
+    }
+
+    private static final class TestTileEntitySign extends TileEntitySign {
+        private final Block block;
+        private final int metadata;
+
+        private TestTileEntitySign(Block block, int metadata) {
+            this.block = block;
+            this.metadata = metadata;
+            this.xCoord = 0;
+            this.zCoord = 0;
+            this.blockType = block;
+            this.blockMetadata = metadata;
+        }
+
+        @Override
+        public Block getBlockType() {
+            return block;
+        }
+
+        @Override
+        public int getBlockMetadata() {
+            return metadata;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- adjust the sign side helper to compute the correct normal for standing signs by negating the sine component
- add unit tests that cover the standing sign front/back detection for key metadata values

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_6902c4565d148323823dfd1562890f11