### PR TITLE
Refine standing sign side detection

### DIFF
--- a/src/main/java/kamkeel/hextext/common/sign/SignSideHelper.java
+++ b/src/main/java/kamkeel/hextext/common/sign/SignSideHelper.java
@@ -3,7 +3,6 @@ package kamkeel.hextext.common.sign;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.tileentity.TileEntitySign;
-import net.minecraft.util.MathHelper;
 
 public final class SignSideHelper {
 
@@ -15,50 +14,69 @@ public final class SignSideHelper {
         double centerX = sign.xCoord + 0.5D;
         double centerZ = sign.zCoord + 0.5D;
 
-        double[] normal = computeFrontNormal(sign.getBlockType(), sign.getBlockMetadata());
+        Block block = sign.getBlockType();
+        int metadata = sign.getBlockMetadata();
 
-        double vecX;
-        double vecZ;
+        double vecX = playerX - centerX;
+        double vecZ = playerZ - centerZ;
 
-        if (sign.getBlockType() == Blocks.standing_sign) {
-            vecX = hitX - 0.5D;
-            vecZ = hitZ - 0.5D;
-
-            if (Math.abs(vecX) < 1.0E-6D && Math.abs(vecZ) < 1.0E-6D) {
-                vecX = playerX - centerX;
-                vecZ = playerZ - centerZ;
+        if (block == Blocks.standing_sign) {
+            if (isNearlyZero(vecX) && isNearlyZero(vecZ)) {
+                vecX = hitX - 0.5D;
+                vecZ = hitZ - 0.5D;
             }
-        } else {
-            vecX = playerX - centerX;
-            vecZ = playerZ - centerZ;
+
+            if (isNearlyZero(vecX) && isNearlyZero(vecZ)) {
+                return SignSide.FRONT;
+            }
+
+            return isFacingFrontStanding(vecX, vecZ, metadata) ? SignSide.FRONT : SignSide.BACK;
         }
 
-        if (vecX == 0.0D && vecZ == 0.0D) {
-            return SignSide.FRONT;
+        double[] normal = computeWallFrontNormal(metadata);
+
+        if (isNearlyZero(vecX) && isNearlyZero(vecZ)) {
+            vecX = normal[0];
+            vecZ = normal[1];
         }
 
         double dot = vecX * normal[0] + vecZ * normal[1];
         return dot >= 0.0D ? SignSide.FRONT : SignSide.BACK;
     }
 
-    private static double[] computeFrontNormal(Block block, int metadata) {
-        if (block == Blocks.wall_sign) {
-            switch (metadata) {
-                case 2:
-                    return new double[] {0.0D, -1.0D};
-                case 3:
-                    return new double[] {0.0D, 1.0D};
-                case 4:
-                    return new double[] {-1.0D, 0.0D};
-                case 5:
-                    return new double[] {1.0D, 0.0D};
-                default:
-                    return new double[] {0.0D, 1.0D};
-            }
-        }
+    private static boolean isFacingFrontStanding(double vecX, double vecZ, int metadata) {
+        double playerAngle = Math.atan2(vecZ, vecX);
+        double facingAngle = computeStandingFacingAngle(metadata);
+        double delta = normalizeRadians(playerAngle - facingAngle);
+        return Math.abs(delta) <= Math.PI / 2.0D;
+    }
 
-        float wrapped = MathHelper.wrapAngleTo180_float((float) (metadata * 360) / 16.0F);
-        double radians = Math.toRadians(wrapped);
-        return new double[] {MathHelper.sin((float) radians), MathHelper.cos((float) radians)};
+    private static double computeStandingFacingAngle(int metadata) {
+        double rotationDegrees = (metadata * 360.0D) / 16.0D;
+        double radians = Math.toRadians(rotationDegrees);
+        return normalizeRadians(radians + (Math.PI / 2.0D));
+    }
+
+    private static double[] computeWallFrontNormal(int metadata) {
+        switch (metadata) {
+            case 2:
+                return new double[] {0.0D, -1.0D};
+            case 3:
+                return new double[] {0.0D, 1.0D};
+            case 4:
+                return new double[] {-1.0D, 0.0D};
+            case 5:
+                return new double[] {1.0D, 0.0D};
+            default:
+                return new double[] {0.0D, 1.0D};
+        }
+    }
+
+    private static double normalizeRadians(double angle) {
+        return Math.atan2(Math.sin(angle), Math.cos(angle));
+    }
+
+    private static boolean isNearlyZero(double value) {
+        return Math.abs(value) < 1.0E-6D;
     }
 }

--- a/src/test/java/kamkeel/hextext/common/sign/SignSideHelperTest.java
+++ b/src/test/java/kamkeel/hextext/common/sign/SignSideHelperTest.java
@@ -9,23 +9,13 @@ import org.junit.Test;
 public class SignSideHelperTest {
 
     @Test
-    public void determinesFrontForStandingSignUsingHitCoordinates() {
-        TestSign sign = new TestSign(Blocks.standing_sign, 0, 10, 10);
-
-        SignSide frontHit = SignSideHelper.determineSide(sign, 10.5D, 12.0D, 0.5F, 0.9F);
-        SignSide backHit = SignSideHelper.determineSide(sign, 10.5D, 12.0D, 0.5F, 0.1F);
-
-        Assert.assertNotEquals(frontHit, backHit);
-    }
-
-    @Test
-    public void fallsBackToPlayerPositionWhenHitIsCentered() {
-        TestSign sign = new TestSign(Blocks.standing_sign, 8, 5, 5);
-
-        SignSide fromSouth = SignSideHelper.determineSide(sign, 4.0D, 4.0D, 0.5F, 0.5F);
-        SignSide fromNorth = SignSideHelper.determineSide(sign, 6.0D, 6.0D, 0.5F, 0.5F);
-
-        Assert.assertNotEquals(fromSouth, fromNorth);
+    public void standingSignDeterminesSideByAngle() {
+        assertStandingFrontBack(0);
+        assertStandingFrontBack(4);
+        assertStandingFrontBack(8);
+        assertStandingFrontBack(12);
+        assertStandingFrontBack(1);
+        assertStandingFrontBack(9);
     }
 
     @Test
@@ -36,6 +26,38 @@ public class SignSideHelperTest {
         SignSide wallBack = SignSideHelper.determineSide(sign, 3.5D, 5.0D, 0.5F, 0.5F);
 
         Assert.assertNotEquals(wallFront, wallBack);
+    }
+
+    @Test
+    public void hitCoordinatesUsedWhenPlayerVectorZero() {
+        TestSign sign = new TestSign(Blocks.standing_sign, 4, 50, 50);
+
+        SignSide frontHit = SignSideHelper.determineSide(sign, 50.5D, 50.5D, 0.1F, 0.5F);
+        SignSide backHit = SignSideHelper.determineSide(sign, 50.5D, 50.5D, 0.9F, 0.5F);
+
+        Assert.assertEquals(SignSide.FRONT, frontHit);
+        Assert.assertEquals(SignSide.BACK, backHit);
+    }
+
+    private void assertStandingFrontBack(int metadata) {
+        TestSign sign = new TestSign(Blocks.standing_sign, metadata, 10 + metadata, 20 + metadata);
+        double[] frontVector = computeFrontVector(metadata);
+        double centerX = sign.xCoord + 0.5D;
+        double centerZ = sign.zCoord + 0.5D;
+
+        SignSide front = SignSideHelper.determineSide(sign, centerX + frontVector[0], centerZ + frontVector[1], 0.5F, 0.5F);
+        SignSide back = SignSideHelper.determineSide(sign, centerX - frontVector[0], centerZ - frontVector[1], 0.5F, 0.5F);
+
+        Assert.assertEquals("Metadata " + metadata + " should treat the front vector as front", SignSide.FRONT, front);
+        Assert.assertEquals("Metadata " + metadata + " should treat the opposite vector as back", SignSide.BACK, back);
+    }
+
+    private double[] computeFrontVector(int metadata) {
+        double rotationDegrees = (metadata * 360.0D) / 16.0D;
+        double radians = Math.toRadians(rotationDegrees);
+        double facing = radians + (Math.PI / 2.0D);
+        double normalized = Math.atan2(Math.sin(facing), Math.cos(facing));
+        return new double[] {Math.cos(normalized), Math.sin(normalized)};
     }
 
     private static final class TestSign extends TileEntitySign {


### PR DESCRIPTION
## Summary
- determine standing sign front/back by comparing the player's angle to the sign's rotation vector
- fall back to hit coordinates when the player position collapses onto the sign center while keeping wall sign behaviour intact
- update the standing sign tests to cover multiple rotation metadata values and the new fallback logic

## Testing
- ./gradlew test --tests "kamkeel.hextext.common.sign.SignSideHelperTest"


------
https://chatgpt.com/codex/tasks/task_e_6902d7237b488323aef1c6e47de48b7a