### PR TITLE
Add server configuration toggles for formatting behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ available formatting tokens and how they interact so you can take full advantage
 ## Standard Minecraft formatting
 
 All of the vanilla `§` style formatting codes continue to work exactly as they do in base Minecraft.
-When using HexText you may prefer to write them with an ampersand for easier typing; HexText will
-normalise them for the game at render time. The supported codes are:
+When using HexText you may prefer to write them with an ampersand for easier typing; if the server
+permits ampersand formatting HexText will normalise them for the game at render time. The supported
+codes are:
 
 | Token        | Description                                     |
 | ------------ | ----------------------------------------------- |
@@ -28,15 +29,16 @@ HexText recognises two RGB-focused syntaxes that let you move beyond the vanilla
 
 ### Inline hex colours
 
-Use `&RRGGBB` to immediately switch to an exact RGB colour (for example `&ff8800`). The change takes
-effect from the character immediately following the code and clears any nested colour spans that were
-active before it.
+Use `&#RRGGBB` (or `§#RRGGBB`) to immediately switch to an exact RGB colour (for example
+`&#ff8800`). The change takes effect from the character immediately following the code and clears any
+nested colour spans that were active before it.
 
 ### Scoped hex spans
 
 Wrap a section of text in `<RRGGBB> ... </RRGGBB>` to apply a colour until the matching closing tag.
 These spans can be nested and work alongside inline hex codes. Closing a span restores the previous
 colour, making it easy to temporarily highlight text without permanently overwriting the stack.
+Servers can disable these HTML-style tags if they want to restrict formatting to inline codes.
 
 Both syntaxes accept upper- or lower-case hexadecimal digits.
 
@@ -66,3 +68,16 @@ code after the colour you want it to animate.
 
 With these tokens you can express complex gradients, highlight sections of text, or animate chat
 messages while remaining compatible with Minecraft's existing formatting system.
+
+## Server configuration
+
+HexText exposes several server-side toggles via the `server` category of its configuration file:
+
+* `enableRgbHtmlFormat` – when `true`, the `<RRGGBB>` and `</RRGGBB>` tags described above are parsed.
+  Set this to `false` to treat them as literal text.
+* `allowSignEditing` – controls whether players can right-click signs with an empty hand to open the
+  editor.
+* `allowAmpersandFormatting` – controls whether ampersands are accepted as an alternative to the
+  section sign for formatting codes and direct RGB colours.
+
+These options make it easy to tailor HexText's behaviour to a server's moderation or gameplay needs.

--- a/src/main/java/kamkeel/hextext/client/render/RenderTextProcessor.java
+++ b/src/main/java/kamkeel/hextext/client/render/RenderTextProcessor.java
@@ -2,6 +2,7 @@ package kamkeel.hextext.client.render;
 
 import kamkeel.hextext.common.util.ColorCodeUtils;
 import kamkeel.hextext.common.util.StringUtils;
+import kamkeel.hextext.config.HexTextConfig;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -25,32 +26,40 @@ public final class RenderTextProcessor {
         Map<Integer, List<RenderInstruction>> instructions = null;
         boolean modified = rawMode && !processed.equals(text);
 
+        boolean allowAmpersand = HexTextConfig.isAmpersandAllowed();
+        boolean allowHtml = HexTextConfig.isRgbHtmlFormatEnabled();
+
         for (int i = 0; i < processed.length(); i++) {
             char current = processed.charAt(i);
 
-            boolean formatIndicator = current == '&' || current == 167;
-            if (formatIndicator && i + 1 < processed.length()) {
-                char next = processed.charAt(i + 1);
-                char lower = Character.toLowerCase(next);
-                int instructionIndex = sanitized.length();
-                boolean usingSectionSign = current == 167;
+            boolean usingSectionSign = current == 167;
+            boolean usingAmpersand = current == '&';
 
-                if (!usingSectionSign && ColorCodeUtils.isValidHexString(processed, i + 1)) {
-                    int rgb = ColorCodeUtils.parseHexColor(processed, i + 1);
-                    if (rgb != -1) {
-                        instructions = ensureInstructionMap(instructions);
-                        instructions.computeIfAbsent(instructionIndex, key -> new ArrayList<>())
-                            .add(RenderInstruction.apply(rgb, true));
-                        if (rawMode) {
-                            sanitized.append('&');
-                            sanitized.append(processed, i + 1, i + 7);
-                        } else {
-                            modified = true;
+            if ((usingSectionSign || (usingAmpersand && allowAmpersand)) && i + 1 < processed.length()) {
+                int instructionIndex = sanitized.length();
+
+                if (processed.charAt(i + 1) == '#') {
+                    int hexStart = i + 2;
+                    if (hexStart + 6 <= processed.length() && ColorCodeUtils.isValidHexString(processed, hexStart)) {
+                        int rgb = ColorCodeUtils.parseHexColor(processed, hexStart);
+                        if (rgb != -1) {
+                            instructions = ensureInstructionMap(instructions);
+                            instructions.computeIfAbsent(instructionIndex, key -> new ArrayList<>())
+                                .add(RenderInstruction.apply(rgb, true));
+                            if (rawMode) {
+                                sanitized.append(current).append('#');
+                                sanitized.append(processed, hexStart, hexStart + 6);
+                            } else {
+                                modified = true;
+                            }
+                            i += 7;
+                            continue;
                         }
-                        i += 6;
-                        continue;
                     }
                 }
+
+                char next = processed.charAt(i + 1);
+                char lower = Character.toLowerCase(next);
 
                 if (ColorCodeUtils.isFormattingCode(lower)) {
                     if (ColorCodeUtils.isEffectCode(lower)) {
@@ -135,7 +144,7 @@ public final class RenderTextProcessor {
                 }
             }
 
-            if (current == '<') {
+            if (allowHtml && current == '<') {
                 if (i + 8 <= processed.length() && processed.charAt(i + 7) == '>'
                     && ColorCodeUtils.isValidHexString(processed, i + 1)) {
                     int rgb = ColorCodeUtils.parseHexColor(processed, i + 1);

--- a/src/main/java/kamkeel/hextext/common/util/ColorCodeUtils.java
+++ b/src/main/java/kamkeel/hextext/common/util/ColorCodeUtils.java
@@ -1,5 +1,7 @@
 package kamkeel.hextext.common.util;
 
+import kamkeel.hextext.config.HexTextConfig;
+
 /**
  * Utility helpers for parsing and working with Minecraft formatting and RGB colour codes.
  */
@@ -105,25 +107,41 @@ public final class ColorCodeUtils {
         }
 
         char c = str.charAt(pos);
+        boolean allowAmpersand = HexTextConfig.isAmpersandAllowed();
+        boolean allowHtml = HexTextConfig.isRgbHtmlFormatEnabled();
 
-        if (c == 167 && pos + 1 < str.length()) {
-            return 2;
+        if (c == 167) {
+            if (pos + 2 <= str.length() && str.charAt(pos + 1) == '#'
+                && pos + 8 <= str.length() && isValidHexString(str, pos + 2)) {
+                return 8;
+            }
+            if (pos + 1 < str.length() && isFormattingCode(str.charAt(pos + 1))) {
+                return 2;
+            }
+            return 0;
         }
 
-        if (c == '&' && pos + 7 <= str.length() && isValidHexString(str, pos + 1)) {
-            return 7;
+        if (c == '&') {
+            if (!allowAmpersand) {
+                return 0;
+            }
+            if (pos + 2 <= str.length() && str.charAt(pos + 1) == '#'
+                && pos + 8 <= str.length() && isValidHexString(str, pos + 2)) {
+                return 8;
+            }
+            if (pos + 1 < str.length() && isFormattingCode(str.charAt(pos + 1))) {
+                return 2;
+            }
+            return 0;
         }
 
-        if (c == '&' && pos + 1 < str.length() && isFormattingCode(str.charAt(pos + 1))) {
-            return 2;
-        }
-
-        if (c == '<' && pos + 9 <= str.length() && str.charAt(pos + 1) == '/' && str.charAt(pos + 8) == '>'
-            && isValidHexString(str, pos + 2)) {
+        if (allowHtml && c == '<' && pos + 9 <= str.length() && str.charAt(pos + 1) == '/'
+            && str.charAt(pos + 8) == '>' && isValidHexString(str, pos + 2)) {
             return 9;
         }
 
-        if (c == '<' && pos + 8 <= str.length() && str.charAt(pos + 7) == '>' && isValidHexString(str, pos + 1)) {
+        if (allowHtml && c == '<' && pos + 8 <= str.length() && str.charAt(pos + 7) == '>'
+            && isValidHexString(str, pos + 1)) {
             return 8;
         }
 

--- a/src/main/java/kamkeel/hextext/common/util/StringUtils.java
+++ b/src/main/java/kamkeel/hextext/common/util/StringUtils.java
@@ -1,5 +1,7 @@
 package kamkeel.hextext.common.util;
 
+import kamkeel.hextext.config.HexTextConfig;
+
 import java.util.ArrayDeque;
 
 /**
@@ -58,7 +60,7 @@ public final class StringUtils {
                 char firstChar = str.charAt(i);
                 String code = str.substring(i, i + codeLen);
 
-                if (codeLen == 7 && firstChar == '&') {
+                if (codeLen == 8 && (firstChar == '&' || firstChar == 167)) {
                     currentColorCode = code;
                     colorStack.clear();
                     styleCodes.setLength(0);
@@ -220,19 +222,19 @@ public final class StringUtils {
 
     private static boolean isHexColorToken(CharSequence input, int index, int codeLen) {
         char start = input.charAt(index);
-        if (codeLen == 7 && start == '&') {
+        if (codeLen == 8 && (start == '&' || start == 167)) {
             return true;
         }
 
-        if (codeLen == 8 && start == '<') {
+        if (HexTextConfig.isRgbHtmlFormatEnabled() && codeLen == 8 && start == '<') {
             return true;
         }
 
-        if (codeLen == 9 && start == '<') {
+        if (HexTextConfig.isRgbHtmlFormatEnabled() && codeLen == 9 && start == '<') {
             return true;
         }
 
-        if (codeLen == 2 && (start == '&' || start == 167)) {
+        if (codeLen == 2 && ((start == '&' && HexTextConfig.isAmpersandAllowed()) || start == 167)) {
             char fmt = Character.toLowerCase(input.charAt(index + 1));
             return ColorCodeUtils.isMinecraftColorCode(fmt) || fmt == 'g';
         }
@@ -243,7 +245,7 @@ public final class StringUtils {
     private static boolean isStyleOrEffectToken(CharSequence input, int index, int codeLen) {
         if (codeLen == 2) {
             char start = input.charAt(index);
-            if (start == '&' || start == 167) {
+            if ((start == '&' && HexTextConfig.isAmpersandAllowed()) || start == 167) {
                 char fmt = Character.toLowerCase(input.charAt(index + 1));
                 return ColorCodeUtils.isStyleCode(fmt) || ColorCodeUtils.isEffectCode(fmt);
             }

--- a/src/main/java/kamkeel/hextext/config/HexTextConfig.java
+++ b/src/main/java/kamkeel/hextext/config/HexTextConfig.java
@@ -10,10 +10,15 @@ import java.io.File;
 public final class HexTextConfig {
 
     public static final String CATEGORY_EFFECTS = "effects";
+    public static final String CATEGORY_SERVER = "server";
 
     private static final float DEFAULT_RAINBOW_SPEED = 3000.0f;
     private static final int DEFAULT_SHAKE_INTERVAL = 100;
     private static final int DEFAULT_IGNITE_INTERVAL = 100;
+
+    private static final boolean DEFAULT_ENABLE_RGB_HTML_FORMAT = false;
+    private static final boolean DEFAULT_ALLOW_SIGN_EDITING = true;
+    private static final boolean DEFAULT_ALLOW_AMPERSAND = true;
 
     private static final float MIN_RAINBOW_SPEED = 1.0f;
     private static final int MIN_SHAKE_INTERVAL = 1;
@@ -28,6 +33,9 @@ public final class HexTextConfig {
     private static float rainbowSpeed = DEFAULT_RAINBOW_SPEED;
     private static int shakeInterval = DEFAULT_SHAKE_INTERVAL;
     private static int igniteInterval = DEFAULT_IGNITE_INTERVAL;
+    private static boolean enableRgbHtmlFormat = DEFAULT_ENABLE_RGB_HTML_FORMAT;
+    private static boolean allowSignEditing = DEFAULT_ALLOW_SIGN_EDITING;
+    private static boolean allowAmpersand = DEFAULT_ALLOW_AMPERSAND;
 
     private HexTextConfig() {
     }
@@ -48,6 +56,8 @@ public final class HexTextConfig {
 
         configuration.addCustomCategoryComment(CATEGORY_EFFECTS,
             "Timing controls for HexText's dynamic formatting effects.");
+        configuration.addCustomCategoryComment(CATEGORY_SERVER,
+            "Server-side behavioural toggles for HexText formatting and sign editing.");
 
         rainbowSpeed = clamp(configuration.getFloat(
             "rainbowCycleDurationMs",
@@ -76,6 +86,27 @@ public final class HexTextConfig {
             "Milliseconds for ignite to fade from bright to dim and back again. Lower values animate faster."
         ), MIN_IGNITE_INTERVAL, MAX_IGNITE_INTERVAL);
 
+        enableRgbHtmlFormat = configuration.getBoolean(
+            "enableRgbHtmlFormat",
+            CATEGORY_SERVER,
+            DEFAULT_ENABLE_RGB_HTML_FORMAT,
+            "Allow the <RRGGBB> and </RRGGBB> HTML-style colour tags to be parsed."
+        );
+
+        allowSignEditing = configuration.getBoolean(
+            "allowSignEditing",
+            CATEGORY_SERVER,
+            DEFAULT_ALLOW_SIGN_EDITING,
+            "Permit players to open the sign editor by right-clicking with an empty hand."
+        );
+
+        allowAmpersand = configuration.getBoolean(
+            "allowAmpersandFormatting",
+            CATEGORY_SERVER,
+            DEFAULT_ALLOW_AMPERSAND,
+            "Enable & as an alternative to the section sign when entering formatting codes."
+        );
+
         if (configuration.hasChanged()) {
             configuration.save();
         }
@@ -93,8 +124,41 @@ public final class HexTextConfig {
         return igniteInterval;
     }
 
+    public static boolean isRgbHtmlFormatEnabled() {
+        return enableRgbHtmlFormat;
+    }
+
+    public static boolean isSignEditingAllowed() {
+        return allowSignEditing;
+    }
+
+    public static boolean isAmpersandAllowed() {
+        return allowAmpersand;
+    }
+
     public static Configuration getConfiguration() {
         return configuration;
+    }
+
+    public static void setEnableRgbHtmlFormat(boolean enabled) {
+        enableRgbHtmlFormat = enabled;
+    }
+
+    public static void setAllowSignEditing(boolean allowed) {
+        allowSignEditing = allowed;
+    }
+
+    public static void setAllowAmpersand(boolean allowed) {
+        allowAmpersand = allowed;
+    }
+
+    public static void resetToDefaults() {
+        rainbowSpeed = DEFAULT_RAINBOW_SPEED;
+        shakeInterval = DEFAULT_SHAKE_INTERVAL;
+        igniteInterval = DEFAULT_IGNITE_INTERVAL;
+        enableRgbHtmlFormat = DEFAULT_ENABLE_RGB_HTML_FORMAT;
+        allowSignEditing = DEFAULT_ALLOW_SIGN_EDITING;
+        allowAmpersand = DEFAULT_ALLOW_AMPERSAND;
     }
 
     private static float clamp(float value, float min, float max) {

--- a/src/main/java/kamkeel/hextext/mixin/early/impl/MixinBlockSign.java
+++ b/src/main/java/kamkeel/hextext/mixin/early/impl/MixinBlockSign.java
@@ -5,6 +5,7 @@ import kamkeel.hextext.api.sign.SignInteractionType;
 import kamkeel.hextext.common.sign.SignSide;
 import kamkeel.hextext.common.sign.SignSideHelper;
 import kamkeel.hextext.common.sign.SignState;
+import kamkeel.hextext.config.HexTextConfig;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.BlockSign;
 import net.minecraft.block.material.Material;
@@ -110,6 +111,14 @@ public abstract class MixinBlockSign extends BlockContainer {
                 }
                 return true;
             }
+        }
+
+        if (stack != null) {
+            return false;
+        }
+
+        if (!HexTextConfig.isSignEditingAllowed()) {
+            return false;
         }
 
         signState.hextext$prepareForEdit(clickedSide);

--- a/src/test/java/kamkeel/hextext/client/render/RenderTextProcessorTest.java
+++ b/src/test/java/kamkeel/hextext/client/render/RenderTextProcessorTest.java
@@ -1,6 +1,9 @@
 package kamkeel.hextext.client.render;
 
+import kamkeel.hextext.config.HexTextConfig;
+
 import org.junit.Test;
+import org.junit.Before;
 
 import java.util.List;
 import java.util.Map;
@@ -9,9 +12,16 @@ import static org.junit.Assert.*;
 
 public class RenderTextProcessorTest {
 
+    @Before
+    public void setUp() {
+        HexTextConfig.resetToDefaults();
+        HexTextConfig.setAllowAmpersand(true);
+        HexTextConfig.setEnableRgbHtmlFormat(true);
+    }
+
     @Test
     public void testNonRawHexProcessing() {
-        RenderTextData data = RenderTextProcessor.prepare("&FFAA11Hello", false);
+        RenderTextData data = RenderTextProcessor.prepare("&#FFAA11Hello", false);
         assertTrue(data.shouldReplaceText());
         assertEquals("Hello", data.getDisplayText());
         assertTrue(data.hasInstructions());
@@ -43,7 +53,7 @@ public class RenderTextProcessorTest {
 
     @Test
     public void testRawHexColor() {
-        RenderTextData data = RenderTextProcessor.prepare("&ABCDEFWorld", true);
+        RenderTextData data = RenderTextProcessor.prepare("&#ABCDEFWorld", true);
         assertFalse(data.shouldReplaceText());
         assertNull(data.getDisplayText());
         Map<Integer, List<RenderInstruction>> instructions = data.getInstructions();
@@ -52,6 +62,23 @@ public class RenderTextProcessorTest {
         RenderInstruction instruction = instructions.get(0).get(0);
         assertEquals(RenderInstruction.Type.APPLY_RGB, instruction.getType());
         assertEquals(0xABCDEF, instruction.getRgb());
+    }
+
+    @Test
+    public void testSectionSignHexProcessing() {
+        RenderTextData data = RenderTextProcessor.prepare("§#123456Hello", false);
+        assertTrue(data.shouldReplaceText());
+        assertEquals("Hello", data.getDisplayText());
+        assertTrue(data.hasInstructions());
+        Map<Integer, List<RenderInstruction>> instructions = data.getInstructions();
+        assertNotNull(instructions);
+        List<RenderInstruction> atZero = instructions.get(0);
+        assertNotNull(atZero);
+        assertFalse(atZero.isEmpty());
+        RenderInstruction instruction = atZero.get(0);
+        assertEquals(RenderInstruction.Type.APPLY_RGB, instruction.getType());
+        assertEquals(0x123456, instruction.getRgb());
+        assertTrue(instruction.shouldClearStack());
     }
 
     @Test
@@ -205,5 +232,27 @@ public class RenderTextProcessorTest {
             }
         }
         assertTrue("Expected shake instruction", sawShake);
+    }
+
+    @Test
+    public void testHtmlRgbDisabledTreatsTagsAsText() {
+        HexTextConfig.setEnableRgbHtmlFormat(false);
+        RenderTextData data = RenderTextProcessor.prepare("<123456>World", false);
+        assertFalse(data.hasInstructions());
+        assertFalse(data.shouldReplaceText());
+        assertNull(data.getDisplayText());
+    }
+
+    @Test
+    public void testAmpersandDisabledTreatsTokensAsText() {
+        HexTextConfig.setAllowAmpersand(false);
+        RenderTextData data = RenderTextProcessor.prepare("&aGreen", false);
+        assertFalse(data.hasInstructions());
+        assertFalse(data.shouldReplaceText());
+        assertNull(data.getDisplayText());
+        RenderTextData rgbData = RenderTextProcessor.prepare("&#FFAA11Text", false);
+        assertFalse(rgbData.hasInstructions());
+        assertFalse(rgbData.shouldReplaceText());
+        assertNull(rgbData.getDisplayText());
     }
 }

--- a/src/test/java/kamkeel/hextext/common/util/ColorCodeUtilsTest.java
+++ b/src/test/java/kamkeel/hextext/common/util/ColorCodeUtilsTest.java
@@ -1,10 +1,20 @@
 package kamkeel.hextext.common.util;
 
+import kamkeel.hextext.config.HexTextConfig;
+
 import org.junit.Test;
+import org.junit.Before;
 
 import static org.junit.Assert.*;
 
 public class ColorCodeUtilsTest {
+
+    @Before
+    public void setUp() {
+        HexTextConfig.resetToDefaults();
+        HexTextConfig.setAllowAmpersand(true);
+        HexTextConfig.setEnableRgbHtmlFormat(true);
+    }
 
     @Test
     public void testValidHexChar() {
@@ -31,11 +41,25 @@ public class ColorCodeUtilsTest {
 
     @Test
     public void testDetectColorCodeLength() {
-        assertEquals(7, ColorCodeUtils.detectColorCodeLength("&123456rest", 0));
+        assertEquals(8, ColorCodeUtils.detectColorCodeLength("&#123456rest", 0));
         assertEquals(2, ColorCodeUtils.detectColorCodeLength("§ares", 0));
         assertEquals(9, ColorCodeUtils.detectColorCodeLength("</ABCDEF>xyz", 0));
         assertEquals(8, ColorCodeUtils.detectColorCodeLength("<ABCDEF>xyz", 0));
         assertEquals(0, ColorCodeUtils.detectColorCodeLength("plain", 0));
+    }
+
+    @Test
+    public void testDetectColorCodeLengthRespectsHtmlToggle() {
+        HexTextConfig.setEnableRgbHtmlFormat(false);
+        assertEquals(0, ColorCodeUtils.detectColorCodeLength("<ABCDEF>xyz", 0));
+        assertEquals(0, ColorCodeUtils.detectColorCodeLength("</ABCDEF>xyz", 0));
+    }
+
+    @Test
+    public void testDetectColorCodeLengthRespectsAmpersandToggle() {
+        HexTextConfig.setAllowAmpersand(false);
+        assertEquals(0, ColorCodeUtils.detectColorCodeLength("&#123456rest", 0));
+        assertEquals(0, ColorCodeUtils.detectColorCodeLength("&aColour", 0));
     }
 
     @Test
@@ -45,7 +69,7 @@ public class ColorCodeUtilsTest {
 
     @Test
     public void testContainsFormattingCodes() {
-        assertTrue(ColorCodeUtils.containsFormattingCodes("Hello &aWorld"));
+        assertTrue(ColorCodeUtils.containsFormattingCodes("Hello &#aabbccWorld"));
         assertFalse(ColorCodeUtils.containsFormattingCodes("Plain text"));
     }
 

--- a/src/test/java/kamkeel/hextext/common/util/StringUtilsTest.java
+++ b/src/test/java/kamkeel/hextext/common/util/StringUtilsTest.java
@@ -1,16 +1,40 @@
 package kamkeel.hextext.common.util;
 
+import kamkeel.hextext.config.HexTextConfig;
+
 import org.junit.Test;
+import org.junit.Before;
 
 import static org.junit.Assert.*;
 
 public class StringUtilsTest {
+
+    @Before
+    public void setUp() {
+        HexTextConfig.resetToDefaults();
+        HexTextConfig.setAllowAmpersand(true);
+        HexTextConfig.setEnableRgbHtmlFormat(true);
+    }
 
     @Test
     public void extractFormatKeepsLatestColour() {
         String input = "&a&lBold<123456>Still";
         String prefix = StringUtils.extractFormatFromString(input);
         assertEquals("<123456>", prefix);
+    }
+
+    @Test
+    public void extractFormatHandlesDirectRgbCode() {
+        String input = "&#112233Hello";
+        String prefix = StringUtils.extractFormatFromString(input);
+        assertEquals("&#112233", prefix);
+    }
+
+    @Test
+    public void extractFormatHandlesSectionSignRgbCode() {
+        String input = "§#445566Hello";
+        String prefix = StringUtils.extractFormatFromString(input);
+        assertEquals("§#445566", prefix);
     }
 
     @Test
@@ -63,6 +87,12 @@ public class StringUtilsTest {
     public void stripStylesKeepsColours() {
         String input = "&a&lBold&o Text";
         assertEquals("&aBold Text", StringUtils.stripStyles(input));
+    }
+
+    @Test
+    public void stripHexColorsRemovesDirectRgbCodes() {
+        String input = "&#abcdefColour";
+        assertEquals("Colour", StringUtils.stripHexColors(input));
     }
 
     @Test

--- a/src/test/java/kamkeel/hextext/config/HexTextConfigTest.java
+++ b/src/test/java/kamkeel/hextext/config/HexTextConfigTest.java
@@ -1,0 +1,38 @@
+package kamkeel.hextext.config;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class HexTextConfigTest {
+
+    @Before
+    public void setUp() {
+        HexTextConfig.resetToDefaults();
+    }
+
+    @After
+    public void tearDown() {
+        HexTextConfig.resetToDefaults();
+    }
+
+    @Test
+    public void defaultsReflectExpectedValues() {
+        assertFalse(HexTextConfig.isRgbHtmlFormatEnabled());
+        assertTrue(HexTextConfig.isSignEditingAllowed());
+        assertTrue(HexTextConfig.isAmpersandAllowed());
+    }
+
+    @Test
+    public void settersOverrideServerFlags() {
+        HexTextConfig.setEnableRgbHtmlFormat(true);
+        HexTextConfig.setAllowSignEditing(false);
+        HexTextConfig.setAllowAmpersand(false);
+
+        assertTrue(HexTextConfig.isRgbHtmlFormatEnabled());
+        assertFalse(HexTextConfig.isSignEditingAllowed());
+        assertFalse(HexTextConfig.isAmpersandAllowed());
+    }
+}


### PR DESCRIPTION
## Summary
- add a server configuration category with toggles for HTML RGB tags, sign editing, and ampersand formatting
- update RGB parsing to require &#RRGGBB sequences and honour the new configuration flags across rendering utilities
- document the new behaviour and expand the unit test suite to cover the new formatting paths

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_6902f230d32c8323a5a0ff5df8d4dca9