### PR TITLE
Add utility to strip standard color codes

### DIFF
--- a/src/main/java/kamkeel/hextext/common/util/StringUtils.java
+++ b/src/main/java/kamkeel/hextext/common/util/StringUtils.java
@@ -175,6 +175,45 @@ public final class StringUtils {
     }
 
     /**
+     * Removes standard Minecraft-style colour codes (e.g. {@code &a}, {@code §c}) while leaving
+     * hex colour tokens and style/effect markers untouched.
+     */
+    public static String stripColors(CharSequence input) {
+        if (input == null) {
+            return null;
+        }
+
+        StringBuilder builder = null;
+        int index = 0;
+        while (index < input.length()) {
+            int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(input, index);
+            if (codeLen > 0) {
+                if (isStandardColorToken(input, index, codeLen)) {
+                    if (builder == null) {
+                        builder = new StringBuilder(input.length());
+                        builder.append(input, 0, index);
+                    }
+                    index += codeLen;
+                    continue;
+                }
+
+                if (builder != null) {
+                    builder.append(input, index, index + codeLen);
+                }
+                index += codeLen;
+                continue;
+            }
+
+            if (builder != null) {
+                builder.append(input.charAt(index));
+            }
+            index++;
+        }
+
+        return builder == null ? input.toString() : builder.toString();
+    }
+
+    /**
      * Removes style/effect formatting codes (bold, italic, rainbow etc.) while leaving colours
      * untouched.
      */
@@ -248,6 +287,18 @@ public final class StringUtils {
             if ((start == '&' && HexText.getActiveProxy().allowAmpersand()) || start == 167) {
                 char fmt = Character.toLowerCase(input.charAt(index + 1));
                 return ColorCodeUtils.isStyleCode(fmt) || ColorCodeUtils.isEffectCode(fmt);
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean isStandardColorToken(CharSequence input, int index, int codeLen) {
+        if (codeLen == 2) {
+            char start = input.charAt(index);
+            if ((start == '&' && HexText.getActiveProxy().allowAmpersand()) || start == 167) {
+                char fmt = Character.toLowerCase(input.charAt(index + 1));
+                return ColorCodeUtils.isMinecraftColorCode(fmt) || fmt == 'g';
             }
         }
 

--- a/src/test/java/kamkeel/hextext/common/util/StringUtilsTest.java
+++ b/src/test/java/kamkeel/hextext/common/util/StringUtilsTest.java
@@ -87,6 +87,24 @@ public class StringUtilsTest {
     }
 
     @Test
+    public void stripColorsRemovesMinecraftCodes() {
+        String input = "&a&lHello §cWorld";
+        assertEquals("&lHello World", StringUtils.stripColors(input));
+    }
+
+    @Test
+    public void stripColorsKeepsHexAndStyles() {
+        String input = "&#123456&lColourful";
+        assertEquals("&#123456&lColourful", StringUtils.stripColors(input));
+    }
+
+    @Test
+    public void stripColorsRemovesRainbowCode() {
+        String input = "&gRainbow";
+        assertEquals("Rainbow", StringUtils.stripColors(input));
+    }
+
+    @Test
     public void stripStylesKeepsColours() {
         String input = "&a&lBold&o Text";
         assertEquals("&aBold Text", StringUtils.stripStyles(input));


### PR DESCRIPTION
## Summary
- add `StringUtils.stripColors` to strip standard Minecraft colour tokens while keeping hex and style codes intact
- extend `StringUtilsTest` with coverage for the new helper

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_69030f7b4c4c8323b1ce15cb185ca9e2