### PR TITLE
Add helper to normalise ampersand formatting codes

### DIFF
--- a/src/main/java/kamkeel/hextext/common/util/StringUtils.java
+++ b/src/main/java/kamkeel/hextext/common/util/StringUtils.java
@@ -47,6 +47,48 @@ public final class StringUtils {
         return builder == null ? text : builder.toString();
     }
 
+    /**
+     * Replaces recognised HexText ampersand formatting codes (e.g. {@code &a}, {@code &#abcdef}) with
+     * section sign equivalents. Non-formatting ampersands are left untouched.
+     *
+     * @param text input containing potential ampersand formatting tokens
+     * @return the input with recognised tokens normalised to use section signs
+     */
+    public static String convertAmpersandsToSectionSigns(String text) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+
+        StringBuilder builder = null;
+        int index = 0;
+
+        while (index < text.length()) {
+            char current = text.charAt(index);
+
+            if (current == '&') {
+                int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(text, index);
+                if (codeLen == 2 || codeLen == 8) {
+                    if (builder == null) {
+                        builder = new StringBuilder(text.length());
+                        builder.append(text, 0, index);
+                    }
+
+                    builder.append(SECTION_SIGN);
+                    builder.append(text, index + 1, index + codeLen);
+                    index += codeLen;
+                    continue;
+                }
+            }
+
+            if (builder != null) {
+                builder.append(current);
+            }
+            index++;
+        }
+
+        return builder == null ? text : builder.toString();
+    }
+
     public static String extractFormatFromString(String str) {
         if (str == null || str.isEmpty()) {
             return "";

--- a/src/test/java/kamkeel/hextext/common/util/StringUtilsTest.java
+++ b/src/test/java/kamkeel/hextext/common/util/StringUtilsTest.java
@@ -75,6 +75,18 @@ public class StringUtilsTest {
     }
 
     @Test
+    public void convertAmpersandsToSectionSignsReplacesRecognisedTokens() {
+        String converted = StringUtils.convertAmpersandsToSectionSigns("&a&lHello &#A1B2C3World");
+        assertEquals("§a§lHello §#A1B2C3World", converted);
+    }
+
+    @Test
+    public void convertAmpersandsToSectionSignsLeavesInvalidAmpersands() {
+        String converted = StringUtils.convertAmpersandsToSectionSigns("&x& Hello &");
+        assertEquals("&x& Hello &", converted);
+    }
+
+    @Test
     public void stripExtrasRemovesAllFormatting() {
         String input = "&a&lBold <123456>Text&n";
         assertEquals("Bold Text", StringUtils.stripExtras(input));


### PR DESCRIPTION
## Summary
- add `StringUtils.convertAmpersandsToSectionSigns` to normalise recognised ampersand formatting tokens
- cover the new helper with unit tests for valid and invalid sequences

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_6903f975ed588323ac9c07ec27944b85