### PR TITLE
Fix ampersand token highlighting in raw rendering

### DIFF
--- a/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
+++ b/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
@@ -85,6 +85,9 @@ public final class FontRendererRenderPipeline {
                 rawTokenSkip--;
             } else {
                 int tokenLength = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(text, index);
+                if (tokenLength == 0) {
+                    tokenLength = detectRawAmpersandTokenLength(text, index);
+                }
                 if (tokenLength > 0) {
                     if (text.charAt(index) != 167) {
                         float width = TokenHighlightUtils.measureLiteralWidth(bridge.getFontRenderer(), text, index, tokenLength);
@@ -115,6 +118,19 @@ public final class FontRendererRenderPipeline {
         for (RenderInstruction instruction : instructions) {
             executeInstruction(instruction);
         }
+    }
+
+    private static int detectRawAmpersandTokenLength(CharSequence text, int index) {
+        if (text == null || index < 0 || index >= text.length() - 1) {
+            return 0;
+        }
+        if (text.charAt(index) != '&') {
+            return 0;
+        }
+        if (text.charAt(index + 1) == '#') {
+            return index + 8 <= text.length() && ColorCodeUtils.isValidHexString(text, index + 2) ? 8 : 0;
+        }
+        return ColorCodeUtils.isFormattingCode(text.charAt(index + 1)) ? 2 : 0;
     }
 
     public void end() {


### PR DESCRIPTION
## Summary
- ensure raw rendering highlights ampersand-based tokens by falling back to raw detection when server configs disable universal ampersand support
- add a helper to recognise raw ampersand colour and hex tokens for highlighting purposes

## Testing
- ./gradlew build *(fails: proxy returned HTTP 502 while downloading fernflower)*

------
https://chatgpt.com/codex/tasks/task_e_6905306cae8083239838dd7e8a413c8e