### PR TITLE
Optimize formatting scanning performance

### DIFF
--- a/src/main/java/kamkeel/hextext/client/render/FormattedTextMetrics.java
+++ b/src/main/java/kamkeel/hextext/client/render/FormattedTextMetrics.java
@@ -26,9 +26,11 @@ public final class FormattedTextMetrics {
         boolean isBold = false;
         final int length = text.length();
 
+        ColorCodeUtils.FormattingEnvironment env = rawMode ? null : ColorCodeUtils.captureFormattingEnvironment(false);
+
         for (int index = 0; index < length; ) {
             if (!rawMode) {
-                int codeLen = ColorCodeUtils.detectColorCodeLength(text, index);
+                int codeLen = ColorCodeUtils.detectColorCodeLength(text, index, false, env);
                 if (codeLen > 0) {
                     if (codeLen == 2 && index + 1 < length) {
                         char fmt = Character.toLowerCase(text.charAt(index + 1));
@@ -79,9 +81,11 @@ public final class FormattedTextMetrics {
         boolean isBold = false;
         final int length = text.length();
 
+        ColorCodeUtils.FormattingEnvironment env = rawMode ? null : ColorCodeUtils.captureFormattingEnvironment(false);
+
         for (int index = 0; index < length; ) {
             if (!rawMode) {
-                int codeLen = ColorCodeUtils.detectColorCodeLength(text, index);
+                int codeLen = ColorCodeUtils.detectColorCodeLength(text, index, false, env);
                 if (codeLen > 0) {
                     if (codeLen == 2 && index + 1 < length) {
                         char fmt = Character.toLowerCase(text.charAt(index + 1));

--- a/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
+++ b/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
@@ -35,6 +35,7 @@ public final class FontRendererRenderPipeline {
     private boolean hasPendingRenderColor;
     private int outlineGlyphIndex = -1;
     private boolean outlineDrawnForCurrentGlyph;
+    private ColorCodeUtils.FormattingEnvironment formattingEnvironmentIgnoreRaw;
 
     public FontRendererRenderPipeline(FontRendererBridge bridge) {
         this.bridge = bridge;
@@ -50,6 +51,7 @@ public final class FontRendererRenderPipeline {
         renderData = RenderTextProcessor.prepare(text, rawMode);
         shadowPass = shadow;
         renderingShadow = shadow;
+        formattingEnvironmentIgnoreRaw = ColorCodeUtils.captureFormattingEnvironment(false);
 
         int initialColor = resolveInitialColor();
         colorState.begin(initialColor, shadow);
@@ -84,7 +86,12 @@ public final class FontRendererRenderPipeline {
             if (rawTokenSkip > 0) {
                 rawTokenSkip--;
             } else {
-                int tokenLength = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(text, index);
+                ColorCodeUtils.FormattingEnvironment env = formattingEnvironmentIgnoreRaw;
+                if (env == null) {
+                    env = ColorCodeUtils.captureFormattingEnvironment(false);
+                    formattingEnvironmentIgnoreRaw = env;
+                }
+                int tokenLength = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(text, index, env);
                 if (tokenLength == 0) {
                     tokenLength = detectRawAmpersandTokenLength(text, index);
                 }

--- a/src/main/java/kamkeel/hextext/common/util/ColorCodeUtils.java
+++ b/src/main/java/kamkeel/hextext/common/util/ColorCodeUtils.java
@@ -1,5 +1,6 @@
 package kamkeel.hextext.common.util;
 
+import kamkeel.hextext.CommonProxy;
 import kamkeel.hextext.HexText;
 
 /**
@@ -8,6 +9,41 @@ import kamkeel.hextext.HexText;
 public final class ColorCodeUtils {
 
     private ColorCodeUtils() {
+    }
+
+    /**
+     * Captures the formatting rules that should be applied when scanning text. The rules are derived
+     * from the active proxy and optionally loosened for raw mode rendering, allowing calling sites to
+     * reuse them across multiple lookups without repeatedly consulting the proxy.
+     */
+    public static final class FormattingEnvironment {
+
+        private final boolean allowHtmlFormatting;
+        private final boolean allowUniversalAmpersand;
+
+        private FormattingEnvironment(boolean allowHtmlFormatting, boolean allowUniversalAmpersand) {
+            this.allowHtmlFormatting = allowHtmlFormatting;
+            this.allowUniversalAmpersand = allowUniversalAmpersand;
+        }
+
+        public boolean allowsHtmlFormatting() {
+            return allowHtmlFormatting;
+        }
+
+        public boolean allowsUniversalAmpersand() {
+            return allowUniversalAmpersand;
+        }
+    }
+
+    public static FormattingEnvironment captureFormattingEnvironment(boolean rawMode) {
+        CommonProxy proxy = HexText.getActiveProxy();
+        boolean allowHtml = proxy == null || proxy.allowHtmlFormatting();
+        boolean allowAmpersand = rawMode || proxy == null || proxy.allowUniversalAmpersand();
+        return new FormattingEnvironment(allowHtml, allowAmpersand);
+    }
+
+    public static FormattingEnvironment captureFormattingEnvironment() {
+        return captureFormattingEnvironment(false);
     }
 
     public static boolean isValidHexChar(char c) {
@@ -103,15 +139,35 @@ public final class ColorCodeUtils {
     }
 
     public static int detectColorCodeLength(CharSequence str, int pos, boolean rawMode) {
+        return detectColorCodeLength(str, pos, rawMode, captureFormattingEnvironment(rawMode));
+    }
+
+    public static int detectColorCodeLength(CharSequence str, int pos, boolean rawMode, FormattingEnvironment env) {
+        if (env == null) {
+            env = captureFormattingEnvironment(rawMode);
+        }
+        return detectColorCodeLength(str, pos, rawMode, env.allowsHtmlFormatting(), env.allowsUniversalAmpersand());
+    }
+
+    public static int detectColorCodeLength(CharSequence str, int pos) {
+        return detectColorCodeLength(str, pos, false);
+    }
+
+    public static int detectColorCodeLengthIgnoringRaw(CharSequence str, int pos) {
+        return detectColorCodeLength(str, pos, false);
+    }
+
+    public static int detectColorCodeLengthIgnoringRaw(CharSequence str, int pos, FormattingEnvironment env) {
+        return detectColorCodeLength(str, pos, false, env);
+    }
+
+    private static int detectColorCodeLength(CharSequence str, int pos, boolean rawMode,
+                                             boolean allowHtml, boolean allowAmpersand) {
         if (str == null || pos < 0 || pos >= str.length() || rawMode) {
             return 0;
         }
 
         char c = str.charAt(pos);
-
-        final boolean allowHtml = HexText.getActiveProxy() == null || HexText.getActiveProxy().allowHtmlFormatting();
-        final boolean allowAmpersand = HexText.getActiveProxy() == null
-            || HexText.getActiveProxy().allowUniversalAmpersand();
 
         if (c == 167) {
             if (pos + 2 <= str.length() && str.charAt(pos + 1) == '#'
@@ -149,14 +205,6 @@ public final class ColorCodeUtils {
         }
 
         return 0;
-    }
-
-    public static int detectColorCodeLength(CharSequence str, int pos) {
-        return detectColorCodeLength(str, pos, false);
-    }
-
-    public static int detectColorCodeLengthIgnoringRaw(CharSequence str, int pos) {
-        return detectColorCodeLength(str, pos, false);
     }
 
     public static int calculateShadowColor(int rgb) {
@@ -237,8 +285,9 @@ public final class ColorCodeUtils {
             return false;
         }
 
+        FormattingEnvironment env = captureFormattingEnvironment(false);
         for (int index = 0; index < input.length(); index++) {
-            if (detectColorCodeLengthIgnoringRaw(input, index) > 0) {
+            if (detectColorCodeLengthIgnoringRaw(input, index, env) > 0) {
                 return true;
             }
         }
@@ -258,8 +307,9 @@ public final class ColorCodeUtils {
             return -1;
         }
 
+        FormattingEnvironment env = captureFormattingEnvironment(false);
         for (int index = start; index < input.length(); index++) {
-            if (detectColorCodeLengthIgnoringRaw(input, index) > 0) {
+            if (detectColorCodeLengthIgnoringRaw(input, index, env) > 0) {
                 return index;
             }
         }

--- a/src/main/java/kamkeel/hextext/common/util/SignTextHelper.java
+++ b/src/main/java/kamkeel/hextext/common/util/SignTextHelper.java
@@ -27,7 +27,18 @@ public final class SignTextHelper {
         if (text == null) {
             return 0;
         }
-        return StringUtils.stripColorCodes(text).length();
+        int visible = 0;
+        ColorCodeUtils.FormattingEnvironment env = ColorCodeUtils.captureFormattingEnvironment(false);
+        for (int index = 0; index < text.length(); ) {
+            int codeLength = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(text, index, env);
+            if (codeLength > 0) {
+                index += codeLength;
+                continue;
+            }
+            visible++;
+            index++;
+        }
+        return visible;
     }
 
     /**
@@ -42,18 +53,13 @@ public final class SignTextHelper {
             return text;
         }
 
-        if (visibleLength(text) <= SIGN_LINE_VISIBLE_LIMIT) {
-            return text;
-        }
-
-        StringBuilder builder = new StringBuilder(text.length());
+        ColorCodeUtils.FormattingEnvironment env = ColorCodeUtils.captureFormattingEnvironment(false);
         int index = 0;
         int visible = 0;
 
         while (index < text.length()) {
-            int codeLength = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(text, index);
+            int codeLength = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(text, index, env);
             if (codeLength > 0) {
-                builder.append(text, index, index + codeLength);
                 index += codeLength;
                 continue;
             }
@@ -62,18 +68,42 @@ public final class SignTextHelper {
                 break;
             }
 
-            builder.append(text.charAt(index));
             visible++;
             index++;
         }
 
-        while (index < text.length()) {
-            int codeLength = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(text, index);
+        if (index >= text.length()) {
+            return text;
+        }
+
+        StringBuilder builder = new StringBuilder(text.length());
+        int copyIndex = 0;
+        visible = 0;
+
+        while (copyIndex < text.length()) {
+            int codeLength = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(text, copyIndex, env);
+            if (codeLength > 0) {
+                builder.append(text, copyIndex, copyIndex + codeLength);
+                copyIndex += codeLength;
+                continue;
+            }
+
+            if (visible >= SIGN_LINE_VISIBLE_LIMIT) {
+                break;
+            }
+
+            builder.append(text.charAt(copyIndex));
+            visible++;
+            copyIndex++;
+        }
+
+        while (copyIndex < text.length()) {
+            int codeLength = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(text, copyIndex, env);
             if (codeLength <= 0) {
                 break;
             }
-            builder.append(text, index, index + codeLength);
-            index += codeLength;
+            builder.append(text, copyIndex, copyIndex + codeLength);
+            copyIndex += codeLength;
         }
 
         return builder.toString();

--- a/src/main/java/kamkeel/hextext/common/util/StringUtils.java
+++ b/src/main/java/kamkeel/hextext/common/util/StringUtils.java
@@ -117,12 +117,13 @@ public final class StringUtils {
 
         StringBuilder builder = null;
         int index = 0;
+        ColorCodeUtils.FormattingEnvironment env = ColorCodeUtils.captureFormattingEnvironment(false);
 
         while (index < text.length()) {
             char current = text.charAt(index);
 
             if (current == SECTION_SIGN) {
-                int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(text, index);
+                int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(text, index, env);
                 if (codeLen == 2 || codeLen == 8) {
                     if (builder == null) {
                         builder = new StringBuilder(text.length());
@@ -153,9 +154,10 @@ public final class StringUtils {
         String currentColorCode = null;
         StringBuilder styleCodes = new StringBuilder();
         ArrayDeque<String> colorStack = new ArrayDeque<>();
+        ColorCodeUtils.FormattingEnvironment env = ColorCodeUtils.captureFormattingEnvironment(false);
 
         for (int i = 0; i < str.length(); ) {
-            int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(str, i);
+            int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(str, i, env);
 
             if (codeLen > 0) {
                 char firstChar = str.charAt(i);
@@ -213,19 +215,27 @@ public final class StringUtils {
             return null;
         }
 
-        StringBuilder builder = new StringBuilder(input.length());
-        for (int index = 0; index < input.length(); ) {
-            int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(input, index);
+        StringBuilder builder = null;
+        int index = 0;
+        ColorCodeUtils.FormattingEnvironment env = ColorCodeUtils.captureFormattingEnvironment(false);
+        while (index < input.length()) {
+            int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(input, index, env);
             if (codeLen > 0) {
+                if (builder == null) {
+                    builder = new StringBuilder(input.length());
+                    builder.append(input, 0, index);
+                }
                 index += codeLen;
                 continue;
             }
 
-            builder.append(input.charAt(index));
+            if (builder != null) {
+                builder.append(input.charAt(index));
+            }
             index++;
         }
 
-        return builder.toString();
+        return builder == null ? input.toString() : builder.toString();
     }
 
     /**
@@ -247,8 +257,9 @@ public final class StringUtils {
 
         StringBuilder builder = null;
         int index = 0;
+        ColorCodeUtils.FormattingEnvironment env = ColorCodeUtils.captureFormattingEnvironment(false);
         while (index < input.length()) {
-            int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(input, index);
+            int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(input, index, env);
             if (codeLen > 0) {
                 if (isHexColorToken(input, index, codeLen)) {
                     if (builder == null) {
@@ -286,8 +297,9 @@ public final class StringUtils {
 
         StringBuilder builder = null;
         int index = 0;
+        ColorCodeUtils.FormattingEnvironment env = ColorCodeUtils.captureFormattingEnvironment(false);
         while (index < input.length()) {
-            int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(input, index);
+            int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(input, index, env);
             if (codeLen > 0) {
                 if (isStandardColorToken(input, index, codeLen)) {
                     if (builder == null) {
@@ -325,8 +337,9 @@ public final class StringUtils {
 
         StringBuilder builder = null;
         int index = 0;
+        ColorCodeUtils.FormattingEnvironment env = ColorCodeUtils.captureFormattingEnvironment(false);
         while (index < input.length()) {
-            int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(input, index);
+            int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(input, index, env);
             if (codeLen > 0) {
                 if (isStyleOrEffectToken(input, index, codeLen)) {
                     if (builder == null) {


### PR DESCRIPTION
## Summary
- cache the active formatting configuration in `ColorCodeUtils` so scanners reuse it instead of re-querying the proxy
- update string/sign helpers and font pipeline to pass a shared formatting environment, avoiding repeated allocations and redundant scans
- streamline sign length clamping and formatted text metrics to bail out early when no trimming is required

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_690544141cf88323bcb8a9e30009aef5