### PR TITLE
Expose rendering helper services for external mods

### DIFF
--- a/docs/angelica-compat-plan.md
+++ b/docs/angelica-compat-plan.md
@@ -1,0 +1,56 @@
+# Angelica ↔ HexText Compatibility Plan
+
+This document outlines the concrete refactor steps Angelica should follow to consume HexText exclusively through its public API using reflection. The goal is to eliminate every dependency on HexText internals while keeping Angelica's HexText integration lightweight and resilient across updates.
+
+## 1. Centralise reflective API bootstrapping
+
+1. Introduce a `HexTextReflection` helper in `com.gtnewhorizons.angelica.compat.hextext` that resolves the HexText entry point on demand:
+   - Load `kamkeel.hextext.api.HexTextApi` via `Class.forName`.
+   - Read `apiVersion()` to ensure it is at least `1.1.0`.
+   - Cache `MethodHandle`s (or plain `Method` objects) for the service accessors Angelica needs: `textRenderer()`, `tokenHighlighter()`, `textFormatter()`, `renderEnvironment()`, `dynamicEffects()`, and `colors()`.
+   - Each lookup should be guarded with logging that identifies when the API is absent or outdated so the compat layer can short-circuit gracefully.
+2. Replace the current direct calls in `HexTextServices` with wrapper methods that delegate to `HexTextReflection` and expose simple Java interfaces (`Object` return types cast through reflection).
+3. Ensure every accessor handles reflection failures by returning `null` and logging once, preventing repeated stack traces during the render loop.
+
+## 2. Rewire rendering-environment checks
+
+1. Modify `HexTextServices` to provide `RenderingEnvironmentService` instances through the reflection bridge.
+2. Update `HexTextCompat` (`com.gtnewhorizons.angelica.compat.hextext.HexTextCompat`) to:
+   - Query `RenderingEnvironmentService.isRawTextRendering()` instead of `FontRenderContext.isRawTextRendering()`.
+   - Gate Angelica's raw-mode stack manipulations behind the new `pushRawTextRendering()`/`popRawTextRendering()` API calls.
+3. Refactor `HexTextTokenHighlighter` and `HexTextColorResolver` to ask `HexTextServices.renderEnvironment()` for the raw-mode flag rather than importing `FontRenderContext` directly.
+
+## 3. Delegate colour utilities to the API
+
+1. Extend `HexTextServices` with a `ColorService` accessor retrieved via reflection.
+2. Change `HexTextCompat.computeShadowColor(int)` to call `ColorService.calculateShadowColor()` so Angelica no longer touches `ColorCodeUtils`.
+3. When HexText is unavailable, preserve the current fallback shadow computation to keep Angelica functional in standalone mode.
+
+## 4. Forward dynamic text effects through the service facade
+
+1. Add a reflective accessor for `DynamicEffectService` inside `HexTextServices`.
+2. Rewrite `HexTextDynamicEffectsHelper` (`com.gtnewhorizons.angelica.compat.hextext.effects`) to:
+   - Cache the service instance on construction and mark itself inactive if it cannot be retrieved.
+   - Delegate `computeRainbowColor`, `computeIgniteColor`, and `computeShakeOffset` directly to the service methods without consulting `HexTextConfig` or `TextEffectMath`.
+3. Update `HexTextCompat.EffectsHelperHolder` so it suppresses Angelica's dynamic effect rendering when the service is missing, mirroring the existing no-op fallback behaviour.
+
+## 5. Normalise render directive handling
+
+1. Validate that `HexTextRenderBridge` only relies on the `RenderPlan` and `RenderDirective` interfaces exposed by the API; adjust the adapter to depend solely on the public getters (already present) and avoid casting to internal implementations.
+2. If additional directive metadata is required in the future, surface those fields through new HexText API accessors rather than peeking into implementation classes.
+
+## 6. Harden failure handling and logging
+
+1. Ensure every reflective call funnels through a shared `CompatLogger` that deduplicates warnings per execution path. The logger should clarify whether Angelica disabled a feature because HexText is missing, outdated, or returned `null`.
+2. During Angelica's startup diagnostics (`ModStatus`), log the detected HexText API version and whether each compat subsystem (rendering, highlighting, effects) activated successfully.
+
+## 7. Testing checklist
+
+1. With HexText present (API ≥ 1.1.0), exercise Angelica's font batching to confirm:
+   - Raw edit mode honours HexText's highlighting and formatting.
+   - Dynamic effects (rainbow/ignite/shake) match HexText's output.
+   - Drop shadows use `ColorService` and remain visually identical.
+2. With HexText absent or API < 1.1.0, verify that Angelica falls back to its vanilla rendering paths without spammy logs.
+3. Toggle Angelica's font renderer module off to confirm the reflection guards keep HexText unaffected.
+
+Following this plan will let Angelica depend exclusively on HexText's stable API contracts while keeping the integration constrained to a handful of reflective entry points.

--- a/src/main/java/kamkeel/hextext/api/HexTextApi.java
+++ b/src/main/java/kamkeel/hextext/api/HexTextApi.java
@@ -1,5 +1,8 @@
 package kamkeel.hextext.api;
 
+import kamkeel.hextext.api.rendering.ColorService;
+import kamkeel.hextext.api.rendering.DynamicEffectService;
+import kamkeel.hextext.api.rendering.RenderingEnvironmentService;
 import kamkeel.hextext.api.rendering.TextRenderService;
 import kamkeel.hextext.api.rendering.TokenHighlightService;
 import kamkeel.hextext.api.sign.SignInteractionRegistry;
@@ -13,7 +16,7 @@ import kamkeel.hextext.api.text.TextSanitizer;
  */
 public final class HexTextApi {
 
-    public static final String API_VERSION = "1.0.0";
+    public static final String API_VERSION = "1.1.0";
 
     private static volatile HexTextApiProvider provider = UninitializedProvider.INSTANCE;
 
@@ -98,6 +101,27 @@ public final class HexTextApi {
         return provider().signState();
     }
 
+    /**
+     * Provides access to contextual information about the HexText rendering pipeline.
+     */
+    public static RenderingEnvironmentService renderEnvironment() {
+        return provider().renderEnvironment();
+    }
+
+    /**
+     * Provides deterministic helpers for computing HexText dynamic effect values.
+     */
+    public static DynamicEffectService dynamicEffects() {
+        return provider().dynamicEffects();
+    }
+
+    /**
+     * Provides common colour helper utilities used by the HexText renderer.
+     */
+    public static ColorService colors() {
+        return provider().colors();
+    }
+
     private static HexTextApiProvider provider() {
         HexTextApiProvider result = provider;
         if (result == UninitializedProvider.INSTANCE) {
@@ -146,6 +170,21 @@ public final class HexTextApi {
 
         @Override
         public SignStateService signState() {
+            throw failure();
+        }
+
+        @Override
+        public RenderingEnvironmentService renderEnvironment() {
+            throw failure();
+        }
+
+        @Override
+        public DynamicEffectService dynamicEffects() {
+            throw failure();
+        }
+
+        @Override
+        public ColorService colors() {
             throw failure();
         }
 

--- a/src/main/java/kamkeel/hextext/api/HexTextApiProvider.java
+++ b/src/main/java/kamkeel/hextext/api/HexTextApiProvider.java
@@ -1,5 +1,8 @@
 package kamkeel.hextext.api;
 
+import kamkeel.hextext.api.rendering.ColorService;
+import kamkeel.hextext.api.rendering.DynamicEffectService;
+import kamkeel.hextext.api.rendering.RenderingEnvironmentService;
 import kamkeel.hextext.api.rendering.TextRenderService;
 import kamkeel.hextext.api.rendering.TokenHighlightService;
 import kamkeel.hextext.api.sign.SignInteractionRegistry;
@@ -52,4 +55,19 @@ public interface HexTextApiProvider {
      * Returns the sign state helper implementation.
      */
     SignStateService signState();
+
+    /**
+     * Returns the rendering environment helper implementation.
+     */
+    RenderingEnvironmentService renderEnvironment();
+
+    /**
+     * Returns the dynamic effect helper implementation.
+     */
+    DynamicEffectService dynamicEffects();
+
+    /**
+     * Returns the colour helper implementation.
+     */
+    ColorService colors();
 }

--- a/src/main/java/kamkeel/hextext/api/rendering/ColorService.java
+++ b/src/main/java/kamkeel/hextext/api/rendering/ColorService.java
@@ -1,0 +1,15 @@
+package kamkeel.hextext.api.rendering;
+
+/**
+ * Helper utilities for colour calculations performed by the HexText renderer.
+ */
+public interface ColorService {
+
+    /**
+     * Computes the default drop-shadow colour derived from the supplied RGB value.
+     *
+     * @param rgb 24-bit RGB colour without an alpha component
+     * @return 24-bit RGB colour representing the recommended shadow shade
+     */
+    int calculateShadowColor(int rgb);
+}

--- a/src/main/java/kamkeel/hextext/api/rendering/DynamicEffectService.java
+++ b/src/main/java/kamkeel/hextext/api/rendering/DynamicEffectService.java
@@ -1,0 +1,36 @@
+package kamkeel.hextext.api.rendering;
+
+/**
+ * Provides deterministic helpers for reproducing HexText's dynamic text effects outside of the
+ * built-in font renderer.
+ */
+public interface DynamicEffectService {
+
+    /**
+     * Computes the RGB colour that should be displayed for a glyph affected by the rainbow effect.
+     *
+     * @param now         current time in milliseconds
+     * @param glyphIndex  zero-based index of the glyph being rendered
+     * @param anchorIndex zero-based index of the glyph that anchors the rainbow effect
+     * @return 24-bit RGB colour without an alpha component
+     */
+    int computeRainbowColor(long now, int glyphIndex, int anchorIndex);
+
+    /**
+     * Computes the RGB colour for a glyph affected by the ignite effect given its base colour.
+     *
+     * @param now       current time in milliseconds
+     * @param baseColor 24-bit RGB colour used as the ignite base
+     * @return 24-bit RGB colour without an alpha component
+     */
+    int computeIgniteColor(long now, int baseColor);
+
+    /**
+     * Computes the vertical shake offset that should be applied to the current glyph.
+     *
+     * @param now        current time in milliseconds
+     * @param glyphIndex zero-based index of the glyph being rendered
+     * @return vertical offset in pixels that should be applied to the glyph
+     */
+    float computeShakeOffset(long now, int glyphIndex);
+}

--- a/src/main/java/kamkeel/hextext/api/rendering/RenderingEnvironmentService.java
+++ b/src/main/java/kamkeel/hextext/api/rendering/RenderingEnvironmentService.java
@@ -1,0 +1,23 @@
+package kamkeel.hextext.api.rendering;
+
+/**
+ * Exposes contextual information about HexText's font rendering pipeline.
+ */
+public interface RenderingEnvironmentService {
+
+    /**
+     * Returns {@code true} when HexText is currently rendering raw text without vanilla formatting
+     * interpretation.
+     */
+    boolean isRawTextRendering();
+
+    /**
+     * Increments the raw text rendering depth for the current thread.
+     */
+    void pushRawTextRendering();
+
+    /**
+     * Decrements the raw text rendering depth for the current thread.
+     */
+    void popRawTextRendering();
+}

--- a/src/main/java/kamkeel/hextext/common/api/HexTextApiBootstrap.java
+++ b/src/main/java/kamkeel/hextext/common/api/HexTextApiBootstrap.java
@@ -3,7 +3,10 @@ package kamkeel.hextext.common.api;
 import kamkeel.hextext.HexText;
 import kamkeel.hextext.api.HexTextApi;
 import kamkeel.hextext.api.HexTextApiProvider;
+import kamkeel.hextext.api.rendering.ColorService;
+import kamkeel.hextext.api.rendering.DynamicEffectService;
 import kamkeel.hextext.api.rendering.RenderPlan;
+import kamkeel.hextext.api.rendering.RenderingEnvironmentService;
 import kamkeel.hextext.api.rendering.TextRenderService;
 import kamkeel.hextext.api.rendering.TokenHighlightService;
 import kamkeel.hextext.api.rendering.HighlightSpan;
@@ -20,8 +23,12 @@ import kamkeel.hextext.common.render.RenderTextProcessor;
 import kamkeel.hextext.common.sign.HexTextSignInteractions;
 import kamkeel.hextext.common.sign.SignSideHelper;
 import kamkeel.hextext.common.util.ColorCodeUtils;
+import kamkeel.hextext.common.util.ColorMath;
 import kamkeel.hextext.common.util.SignTextHelper;
 import kamkeel.hextext.common.util.StringUtils;
+import kamkeel.hextext.common.util.TextEffectMath;
+import kamkeel.hextext.config.HexTextConfig;
+import kamkeel.hextext.client.render.FontRenderContext;
 import net.minecraft.tileentity.TileEntitySign;
 
 import java.util.Arrays;
@@ -53,6 +60,9 @@ public final class HexTextApiBootstrap {
         private final TextRenderService textRenderer = new TextRenderServiceImpl();
         private final TokenHighlightService tokenHighlighter = new TokenHighlightServiceImpl();
         private final SignStateService signState = new SignStateServiceImpl();
+        private final RenderingEnvironmentService renderEnvironment = new RenderingEnvironmentServiceImpl();
+        private final DynamicEffectService dynamicEffects = new DynamicEffectServiceImpl();
+        private final ColorService colors = new ColorServiceImpl();
 
         @Override
         public String modVersion() {
@@ -92,6 +102,85 @@ public final class HexTextApiBootstrap {
         @Override
         public SignStateService signState() {
             return signState;
+        }
+
+        @Override
+        public RenderingEnvironmentService renderEnvironment() {
+            return renderEnvironment;
+        }
+
+        @Override
+        public DynamicEffectService dynamicEffects() {
+            return dynamicEffects;
+        }
+
+        @Override
+        public ColorService colors() {
+            return colors;
+        }
+
+        private final class RenderingEnvironmentServiceImpl implements RenderingEnvironmentService {
+
+            @Override
+            public boolean isRawTextRendering() {
+                return FontRenderContext.isRawTextRendering();
+            }
+
+            @Override
+            public void pushRawTextRendering() {
+                FontRenderContext.pushRawTextRendering();
+            }
+
+            @Override
+            public void popRawTextRendering() {
+                FontRenderContext.popRawTextRendering();
+            }
+        }
+
+        private final class DynamicEffectServiceImpl implements DynamicEffectService {
+
+            private static final float RAINBOW_SPREAD_DEGREES = 12.0f;
+            private static final float IGNITE_MIN_FACTOR = 0.35f;
+            private static final float SHAKE_VERTICAL_RANGE = 1.05f;
+
+            @Override
+            public int computeRainbowColor(long now, int glyphIndex, int anchorIndex) {
+                return TextEffectMath.computeRainbowColor(
+                    now,
+                    HexTextConfig.getRainbowSpeed(),
+                    glyphIndex,
+                    anchorIndex,
+                    RAINBOW_SPREAD_DEGREES
+                );
+            }
+
+            @Override
+            public int computeIgniteColor(long now, int baseColor) {
+                float brightness = TextEffectMath.computeIgniteBrightness(
+                    now,
+                    HexTextConfig.getIgniteInterval(),
+                    IGNITE_MIN_FACTOR
+                );
+                return ColorMath.scaleBrightness(baseColor, brightness);
+            }
+
+            @Override
+            public float computeShakeOffset(long now, int glyphIndex) {
+                long seed = TextEffectMath.computeShakeSeed(
+                    glyphIndex,
+                    now,
+                    HexTextConfig.getShakeInterval()
+                );
+                return TextEffectMath.computeShakeOffset(seed, SHAKE_VERTICAL_RANGE);
+            }
+        }
+
+        private final class ColorServiceImpl implements ColorService {
+
+            @Override
+            public int calculateShadowColor(int rgb) {
+                return ColorCodeUtils.calculateShadowColor(rgb);
+            }
         }
 
         private final class SignTextServiceImpl implements SignTextService {

--- a/src/main/java/kamkeel/hextext/common/compat/AngelicaCompatibility.java
+++ b/src/main/java/kamkeel/hextext/common/compat/AngelicaCompatibility.java
@@ -1,0 +1,196 @@
+package kamkeel.hextext.common.compat;
+
+import cpw.mods.fml.common.Loader;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Detects whether Angelica is present with its font renderer mixin enabled so HexText can gracefully
+ * back off from installing its own font renderer hooks.
+ */
+public final class AngelicaCompatibility {
+
+    private static final Logger LOGGER = LogManager.getLogger("HexText|AngelicaCompat");
+    private static final String ANGELICA_MOD_ID = "angelica";
+    private static final String ANGELICA_FONT_RENDERER_MIXIN =
+        "com.gtnewhorizons.angelica.mixins.early.angelica.fontrenderer.MixinFontRenderer";
+    private static final String ANGELICA_MIXINS_ENUM = "com.gtnewhorizons.angelica.mixins.Mixins";
+    private static final String ANGELICA_FONT_RENDERER_ENUM = "ANGELICA_FONT_RENDERER";
+    private static final String MIXIN_BUILDER_CLASS = "com.gtnewhorizon.gtnhmixins.builders.MixinBuilder";
+    private static final String ANGELICA_CONFIG_CLASS = "com.gtnewhorizons.angelica.config.AngelicaConfig";
+    private static final String ANGELICA_FONT_CONFIG_FIELD = "enableFontRenderer";
+
+    private static volatile Boolean cachedResult;
+
+    private AngelicaCompatibility() {}
+
+    /**
+     * Returns {@code true} when HexText should skip applying its font renderer mixin because Angelica will
+     * provide its own implementation.
+     */
+    public static boolean shouldDisableHexTextFontRendererMixin() {
+        Boolean result = cachedResult;
+        if (result != null) {
+            return result;
+        }
+        result = detectAngelicaFontRendererMixin();
+        cachedResult = result;
+        return result;
+    }
+
+    private static boolean detectAngelicaFontRendererMixin() {
+        if (!isAngelicaPresent()) {
+            return false;
+        }
+
+        if (!isClassPresent(ANGELICA_FONT_RENDERER_MIXIN)) {
+            LOGGER.info("Angelica detected but no font renderer mixin class present; keeping HexText mixin enabled.");
+            return false;
+        }
+
+        Boolean builderDecision = queryMixinBuilderState();
+        if (builderDecision != null) {
+            if (!builderDecision.booleanValue()) {
+                LOGGER.info(
+                    "Angelica font renderer mixin reported as disabled by builder state; keeping HexText mixin enabled.");
+                return false;
+            }
+            LOGGER.info("Angelica font renderer mixin reported as active; disabling HexText font renderer mixin.");
+            return true;
+        }
+
+        Boolean configDecision = readAngelicaFontRendererConfig();
+        if (configDecision != null) {
+            if (!configDecision.booleanValue()) {
+                LOGGER.info(
+                    "Angelica font renderer mixin disabled through configuration; keeping HexText mixin enabled.");
+                return false;
+            }
+            LOGGER.info(
+                "Angelica font renderer mixin enabled through configuration; disabling HexText font renderer mixin.");
+            return true;
+        }
+
+        LOGGER.warn(
+            "Angelica detected but unable to determine font renderer mixin state; disabling HexText mixin as a safeguard.");
+        return true;
+    }
+
+    private static boolean isAngelicaPresent() {
+        try {
+            return Loader.isModLoaded(ANGELICA_MOD_ID);
+        } catch (Throwable t) {
+            LOGGER.warn("Failed to query Forge mod loader for Angelica presence", t);
+            return isClassPresent("com.gtnewhorizons.angelica.AngelicaMod");
+        }
+    }
+
+    private static Boolean queryMixinBuilderState() {
+        try {
+            Class<?> mixinsEnum = Class.forName(ANGELICA_MIXINS_ENUM, false, AngelicaCompatibility.class.getClassLoader());
+            if (!mixinsEnum.isEnum()) {
+                return null;
+            }
+            @SuppressWarnings("unchecked")
+            Enum<?> fontEntry = Enum.valueOf((Class<Enum>) mixinsEnum, ANGELICA_FONT_RENDERER_ENUM);
+            Object builder = mixinsEnum.getMethod("getBuilder").invoke(fontEntry);
+            if (builder == null) {
+                return null;
+            }
+
+            Class<?> builderClass = Class.forName(MIXIN_BUILDER_CLASS, false, builder.getClass().getClassLoader());
+
+            Set<String> mixinNames = extractMixinNames(builder, builderClass);
+            if (!mixinNames.contains("angelica.fontrenderer.MixinFontRenderer")) {
+                return Boolean.FALSE;
+            }
+
+            Boolean decision = evaluateBuilderApplicability(builder, builderClass);
+            if (decision != null) {
+                return decision;
+            }
+        } catch (ReflectiveOperationException | LinkageError ex) {
+            LOGGER.debug("Unable to query Angelica mixin builder state", ex);
+        }
+        return null;
+    }
+
+    private static Set<String> extractMixinNames(Object builder, Class<?> builderClass)
+        throws ReflectiveOperationException {
+        Object raw = null;
+        try {
+            raw = builderClass.getMethod("getClientMixins").invoke(builder);
+        } catch (NoSuchMethodException ignored) {
+            // Fall back to a generic accessor below.
+        }
+
+        if (raw == null) {
+            for (String candidate : Arrays.asList("clientMixins", "getClientMixinClasses", "getMixins")) {
+                try {
+                    raw = builderClass.getMethod(candidate).invoke(builder);
+                    break;
+                } catch (NoSuchMethodException ignored) {
+                    // Try next method name.
+                }
+            }
+        }
+
+        if (raw instanceof String[]) {
+            return new HashSet<>(Arrays.asList((String[]) raw));
+        }
+        if (raw instanceof Collection) {
+            Collection<?> collection = (Collection<?>) raw;
+            Set<String> values = new HashSet<>();
+            for (Object entry : collection) {
+                if (entry instanceof String) {
+                    values.add((String) entry);
+                }
+            }
+            return values;
+        }
+        return Collections.emptySet();
+    }
+
+    private static Boolean evaluateBuilderApplicability(Object builder, Class<?> builderClass)
+        throws ReflectiveOperationException {
+        for (String candidate : Arrays.asList("shouldApply", "shouldApplyMixins", "isEnabled")) {
+            try {
+                Object value = builderClass.getMethod(candidate).invoke(builder);
+                if (value instanceof Boolean) {
+                    return (Boolean) value;
+                }
+            } catch (NoSuchMethodException ignored) {
+                // Try next method name.
+            }
+        }
+        return null;
+    }
+
+    private static Boolean readAngelicaFontRendererConfig() {
+        try {
+            Class<?> config = Class.forName(ANGELICA_CONFIG_CLASS, false, AngelicaCompatibility.class.getClassLoader());
+            Field field = config.getField(ANGELICA_FONT_CONFIG_FIELD);
+            if (field.getType() == boolean.class) {
+                return field.getBoolean(null);
+            }
+        } catch (ReflectiveOperationException ex) {
+            LOGGER.debug("Unable to query Angelica font renderer configuration", ex);
+        }
+        return null;
+    }
+
+    private static boolean isClassPresent(String className) {
+        try {
+            Class.forName(className, false, AngelicaCompatibility.class.getClassLoader());
+            return true;
+        } catch (ClassNotFoundException | LinkageError ex) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/kamkeel/hextext/mixin/early/HexTextEarlyMixins.java
+++ b/src/main/java/kamkeel/hextext/mixin/early/HexTextEarlyMixins.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import kamkeel.hextext.common.compat.AngelicaCompatibility;
+
 public final class HexTextEarlyMixins implements IMixinConfigPlugin {
 
     private static final MixinEnvironment.Side SIDE = MixinEnvironment.getCurrentEnvironment().getSide();
@@ -37,7 +39,9 @@ public final class HexTextEarlyMixins implements IMixinConfigPlugin {
     public List<String> getMixins() {
         List<String> mixins = new ArrayList<>();
         if (SIDE == MixinEnvironment.Side.CLIENT) {
-            mixins.add("client.MixinFontRenderer");
+            if (!AngelicaCompatibility.shouldDisableHexTextFontRendererMixin()) {
+                mixins.add("client.MixinFontRenderer");
+            }
             mixins.add("client.MixinGuiNewChat");
             mixins.add("client.MixinGuiTextField");
             mixins.add("client.MixinGuiChat");


### PR DESCRIPTION
## Summary
- add RenderingEnvironmentService, DynamicEffectService, and ColorService to the public API
- expose the new services through HexTextApi/HexTextApiProvider and implement them in the bootstrap provider
- bump the API version to 1.1.0 so dependents can detect the expanded surface
- document Angelica's reflection-based integration plan and gate HexText's font renderer mixin behind Angelica detection

## Testing
- ./gradlew check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e7c71ae608323b16627decbd97c24)