### PR TITLE
Refine formatting helpers and raw text rendering

### DIFF
--- a/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
+++ b/src/main/java/kamkeel/hextext/client/render/font/FontRendererRenderPipeline.java
@@ -95,7 +95,7 @@ public final class FontRendererRenderPipeline {
                 }
                 int tokenLength = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(text, index, env);
                 if (tokenLength == 0) {
-                    tokenLength = detectRawAmpersandTokenLength(text, index);
+                    tokenLength = ColorCodeUtils.detectAmpersandFormattingCodeLength(text, index);
                 }
                 if (tokenLength > 0) {
                     if (text.charAt(index) != 167) {
@@ -129,19 +129,6 @@ public final class FontRendererRenderPipeline {
                 executeInstruction((RenderDirectiveImpl) instruction);
             }
         }
-    }
-
-    private static int detectRawAmpersandTokenLength(CharSequence text, int index) {
-        if (text == null || index < 0 || index >= text.length() - 1) {
-            return 0;
-        }
-        if (text.charAt(index) != '&') {
-            return 0;
-        }
-        if (text.charAt(index + 1) == '#') {
-            return index + 8 <= text.length() && ColorCodeUtils.isValidHexString(text, index + 2) ? 8 : 0;
-        }
-        return ColorCodeUtils.isFormattingCode(text.charAt(index + 1)) ? 2 : 0;
     }
 
     public void end() {

--- a/src/main/java/kamkeel/hextext/common/render/RenderTextProcessor.java
+++ b/src/main/java/kamkeel/hextext/common/render/RenderTextProcessor.java
@@ -66,14 +66,12 @@ public final class RenderTextProcessor {
                 char lower = Character.toLowerCase(next);
 
                 if (ColorCodeUtils.isFormattingCode(lower)) {
-                    if (ColorCodeUtils.isEffectCode(lower)) {
+                    boolean isEffect = ColorCodeUtils.isEffectCode(lower);
+                    if (isEffect) {
                         directives = ensureDirectiveMap(directives);
                         List<RenderDirective> bucket =
                             directives.computeIfAbsent(directiveIndex, key -> new ArrayList<>());
                         switch (lower) {
-                            case 'g':
-                                bucket.add(RenderDirectiveImpl.setRainbow(true, directiveIndex));
-                                break;
                             case 'h':
                                 bucket.add(RenderDirectiveImpl.setDinnerbone(true));
                                 break;
@@ -96,14 +94,17 @@ public final class RenderTextProcessor {
                     }
 
                     boolean isReset = ColorCodeUtils.isResetCode(lower);
-                    boolean isColor = ColorCodeUtils.isMinecraftColorCode(lower);
+                    boolean isRainbow = ColorCodeUtils.isRainbowCode(lower);
+                    boolean isColor = isRainbow || ColorCodeUtils.isMinecraftColorCode(lower);
                     boolean isStyle = ColorCodeUtils.isStyleCode(lower);
 
                     directives = ensureDirectiveMap(directives);
                     List<RenderDirective> bucket =
                         directives.computeIfAbsent(directiveIndex, key -> new ArrayList<>());
 
-                    if (isColor) {
+                    if (isRainbow) {
+                        bucket.add(RenderDirectiveImpl.setRainbow(true, directiveIndex));
+                    } else if (isColor) {
                         int colorIndex = ColorCodeUtils.getMinecraftColorIndex(lower);
                         if (colorIndex >= 0) {
                             bucket.add(RenderDirectiveImpl.applyVanillaColor(colorIndex));

--- a/src/main/java/kamkeel/hextext/common/util/ColorCodeUtils.java
+++ b/src/main/java/kamkeel/hextext/common/util/ColorCodeUtils.java
@@ -75,23 +75,19 @@ public final class ColorCodeUtils {
     }
 
     public static boolean isFormattingCode(char c) {
-        char lower = Character.toLowerCase(c);
-        return isMinecraftColorCode(lower)
-            || lower == 'g'
-            || lower == 'h'
-            || lower == 'i'
-            || lower == 'j'
-            || isStyleCode(lower)
-            || isResetCode(lower);
+        return categorizeFormatCode(c) != FormatCodeCategory.NONE;
     }
 
     public static boolean isMinecraftColorCode(char c) {
-        char lower = Character.toLowerCase(c);
-        return (lower >= '0' && lower <= '9') || (lower >= 'a' && lower <= 'f');
+        return categorizeFormatCode(c) == FormatCodeCategory.MINECRAFT_COLOR;
+    }
+
+    public static boolean isRainbowCode(char c) {
+        return categorizeFormatCode(c) == FormatCodeCategory.RAINBOW;
     }
 
     public static int getMinecraftColorIndex(char c) {
-        char lower = Character.toLowerCase(c);
+        char lower = normalizeFormatCodeChar(c);
         if (lower >= '0' && lower <= '9') {
             return lower - '0';
         }
@@ -102,17 +98,15 @@ public final class ColorCodeUtils {
     }
 
     public static boolean isStyleCode(char c) {
-        char lower = Character.toLowerCase(c);
-        return lower == 'k' || lower == 'l' || lower == 'm' || lower == 'n' || lower == 'o';
+        return categorizeFormatCode(c) == FormatCodeCategory.STYLE;
     }
 
     public static boolean isEffectCode(char c) {
-        char lower = Character.toLowerCase(c);
-        return lower == 'g' || lower == 'h' || lower == 'i' || lower == 'j';
+        return categorizeFormatCode(c) == FormatCodeCategory.EFFECT;
     }
 
     public static boolean isResetCode(char c) {
-        return Character.toLowerCase(c) == 'r';
+        return categorizeFormatCode(c) == FormatCodeCategory.RESET;
     }
 
     public static int parseHexColor(String hex) {
@@ -175,28 +169,14 @@ public final class ColorCodeUtils {
         char c = str.charAt(pos);
 
         if (c == 167) {
-            if (pos + 2 <= str.length() && str.charAt(pos + 1) == '#'
-                && pos + 8 <= str.length() && isValidHexString(str, pos + 2)) {
-                return 8;
-            }
-            if (pos + 1 < str.length() && isFormattingCode(str.charAt(pos + 1))) {
-                return 2;
-            }
-            return 0;
+            return detectPrefixedFormattingCode(str, pos);
         }
 
         if (c == '&') {
             if (!allowAmpersand) {
                 return 0;
             }
-            if (pos + 2 <= str.length() && str.charAt(pos + 1) == '#'
-                && pos + 8 <= str.length() && isValidHexString(str, pos + 2)) {
-                return 8;
-            }
-            if (pos + 1 < str.length() && isFormattingCode(str.charAt(pos + 1))) {
-                return 2;
-            }
-            return 0;
+            return detectPrefixedFormattingCode(str, pos);
         }
 
         if (allowHtml && c == '<' && pos + 9 <= str.length() && str.charAt(pos + 1) == '/'
@@ -212,8 +192,65 @@ public final class ColorCodeUtils {
         return 0;
     }
 
+    public static int detectAmpersandFormattingCodeLength(CharSequence text, int index) {
+        if (text == null || index < 0 || index >= text.length()) {
+            return 0;
+        }
+        if (text.charAt(index) != '&') {
+            return 0;
+        }
+        return detectPrefixedFormattingCode(text, index);
+    }
+
     public static int calculateShadowColor(int rgb) {
         return (rgb & 0xFCFCFC) >> 2;
+    }
+
+    private enum FormatCodeCategory {
+        NONE,
+        MINECRAFT_COLOR,
+        RAINBOW,
+        STYLE,
+        EFFECT,
+        RESET
+    }
+
+    private static FormatCodeCategory categorizeFormatCode(char c) {
+        char lower = normalizeFormatCodeChar(c);
+        if (lower >= '0' && lower <= '9') {
+            return FormatCodeCategory.MINECRAFT_COLOR;
+        }
+        if (lower >= 'a' && lower <= 'f') {
+            return FormatCodeCategory.MINECRAFT_COLOR;
+        }
+        if (lower == 'g') {
+            return FormatCodeCategory.RAINBOW;
+        }
+        if (lower == 'k' || lower == 'l' || lower == 'm' || lower == 'n' || lower == 'o') {
+            return FormatCodeCategory.STYLE;
+        }
+        if (lower == 'h' || lower == 'i' || lower == 'j') {
+            return FormatCodeCategory.EFFECT;
+        }
+        if (lower == 'r') {
+            return FormatCodeCategory.RESET;
+        }
+        return FormatCodeCategory.NONE;
+    }
+
+    private static char normalizeFormatCodeChar(char c) {
+        return Character.toLowerCase(c);
+    }
+
+    private static int detectPrefixedFormattingCode(CharSequence str, int pos) {
+        if (str == null || pos < 0 || pos + 1 >= str.length()) {
+            return 0;
+        }
+        char next = str.charAt(pos + 1);
+        if (next == '#') {
+            return pos + 8 <= str.length() && isValidHexString(str, pos + 2) ? 8 : 0;
+        }
+        return isFormattingCode(next) ? 2 : 0;
     }
 
     public static int hsvToRgb(float hue, float saturation, float value) {

--- a/src/main/java/kamkeel/hextext/common/util/StringUtils.java
+++ b/src/main/java/kamkeel/hextext/common/util/StringUtils.java
@@ -1,7 +1,5 @@
 package kamkeel.hextext.common.util;
 
-import kamkeel.hextext.HexText;
-
 import java.util.ArrayDeque;
 
 /**
@@ -66,7 +64,7 @@ public final class StringUtils {
             char current = text.charAt(index);
 
             if (current == '&') {
-                int codeLen = detectAmpersandFormattingCodeLength(text, index);
+                int codeLen = ColorCodeUtils.detectAmpersandFormattingCodeLength(text, index);
                 if (codeLen == 2 || codeLen == 8) {
                     if (builder == null) {
                         builder = new StringBuilder(text.length());
@@ -87,19 +85,6 @@ public final class StringUtils {
         }
 
         return builder == null ? text : builder.toString();
-    }
-
-    private static int detectAmpersandFormattingCodeLength(CharSequence text, int index) {
-        if (text == null || index < 0 || index >= text.length() - 1) {
-            return 0;
-        }
-
-        char next = text.charAt(index + 1);
-        if (next == '#') {
-            return index + 8 <= text.length() && ColorCodeUtils.isValidHexString(text, index + 2) ? 8 : 0;
-        }
-
-        return ColorCodeUtils.isFormattingCode(next) ? 2 : 0;
     }
 
     /**
@@ -179,7 +164,7 @@ public final class StringUtils {
                 } else if (codeLen == 2) {
                     char fmt = Character.toLowerCase(str.charAt(i + 1));
 
-                    if (ColorCodeUtils.isMinecraftColorCode(fmt) || fmt == 'g') {
+                    if (ColorCodeUtils.isMinecraftColorCode(fmt) || ColorCodeUtils.isRainbowCode(fmt)) {
                         currentColorCode = code;
                         colorStack.clear();
                         styleCodes.setLength(0);
@@ -214,28 +199,13 @@ public final class StringUtils {
         if (input == null) {
             return null;
         }
-
-        StringBuilder builder = null;
-        int index = 0;
-        ColorCodeUtils.FormattingEnvironment env = ColorCodeUtils.captureFormattingEnvironment(false);
-        while (index < input.length()) {
-            int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(input, index, env);
-            if (codeLen > 0) {
-                if (builder == null) {
-                    builder = new StringBuilder(input.length());
-                    builder.append(input, 0, index);
-                }
-                index += codeLen;
-                continue;
+        return stripTokens(input, new TokenPredicate() {
+            @Override
+            public boolean remove(CharSequence sequence, int index, int length,
+                                   ColorCodeUtils.FormattingEnvironment env) {
+                return true;
             }
-
-            if (builder != null) {
-                builder.append(input.charAt(index));
-            }
-            index++;
-        }
-
-        return builder == null ? input.toString() : builder.toString();
+        });
     }
 
     /**
@@ -254,36 +224,14 @@ public final class StringUtils {
         if (input == null) {
             return null;
         }
-
-        StringBuilder builder = null;
-        int index = 0;
-        ColorCodeUtils.FormattingEnvironment env = ColorCodeUtils.captureFormattingEnvironment(false);
-        while (index < input.length()) {
-            int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(input, index, env);
-            if (codeLen > 0) {
-                if (isHexColorToken(input, index, codeLen)) {
-                    if (builder == null) {
-                        builder = new StringBuilder(input.length());
-                        builder.append(input, 0, index);
-                    }
-                    index += codeLen;
-                    continue;
-                }
-
-                if (builder != null) {
-                    builder.append(input, index, index + codeLen);
-                }
-                index += codeLen;
-                continue;
+        return stripTokens(input, new TokenPredicate() {
+            @Override
+            public boolean remove(CharSequence sequence, int index, int length,
+                                   ColorCodeUtils.FormattingEnvironment env) {
+                TokenCategory category = classifyToken(sequence, index, length, env);
+                return category == TokenCategory.HEX_COLOR || category == TokenCategory.STANDARD_COLOR;
             }
-
-            if (builder != null) {
-                builder.append(input.charAt(index));
-            }
-            index++;
-        }
-
-        return builder == null ? input.toString() : builder.toString();
+        });
     }
 
     /**
@@ -294,36 +242,13 @@ public final class StringUtils {
         if (input == null) {
             return null;
         }
-
-        StringBuilder builder = null;
-        int index = 0;
-        ColorCodeUtils.FormattingEnvironment env = ColorCodeUtils.captureFormattingEnvironment(false);
-        while (index < input.length()) {
-            int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(input, index, env);
-            if (codeLen > 0) {
-                if (isStandardColorToken(input, index, codeLen)) {
-                    if (builder == null) {
-                        builder = new StringBuilder(input.length());
-                        builder.append(input, 0, index);
-                    }
-                    index += codeLen;
-                    continue;
-                }
-
-                if (builder != null) {
-                    builder.append(input, index, index + codeLen);
-                }
-                index += codeLen;
-                continue;
+        return stripTokens(input, new TokenPredicate() {
+            @Override
+            public boolean remove(CharSequence sequence, int index, int length,
+                                   ColorCodeUtils.FormattingEnvironment env) {
+                return classifyToken(sequence, index, length, env) == TokenCategory.STANDARD_COLOR;
             }
-
-            if (builder != null) {
-                builder.append(input.charAt(index));
-            }
-            index++;
-        }
-
-        return builder == null ? input.toString() : builder.toString();
+        });
     }
 
     /**
@@ -334,23 +259,35 @@ public final class StringUtils {
         if (input == null) {
             return null;
         }
+        return stripTokens(input, new TokenPredicate() {
+            @Override
+            public boolean remove(CharSequence sequence, int index, int length,
+                                   ColorCodeUtils.FormattingEnvironment env) {
+                return classifyToken(sequence, index, length, env) == TokenCategory.STYLE_OR_EFFECT;
+            }
+        });
+    }
 
+    /**
+     * @return {@code true} when the input contains any formatting codes understood by HexText.
+     */
+    public static boolean containsFormattingCodes(CharSequence input) {
+        return ColorCodeUtils.containsFormattingCodes(input);
+    }
+
+    private static String stripTokens(CharSequence input, TokenPredicate predicate) {
         StringBuilder builder = null;
         int index = 0;
         ColorCodeUtils.FormattingEnvironment env = ColorCodeUtils.captureFormattingEnvironment(false);
+
         while (index < input.length()) {
             int codeLen = ColorCodeUtils.detectColorCodeLengthIgnoringRaw(input, index, env);
             if (codeLen > 0) {
-                if (isStyleOrEffectToken(input, index, codeLen)) {
-                    if (builder == null) {
-                        builder = new StringBuilder(input.length());
-                        builder.append(input, 0, index);
-                    }
-                    index += codeLen;
-                    continue;
+                if (builder == null) {
+                    builder = new StringBuilder(input.length());
+                    builder.append(input, 0, index);
                 }
-
-                if (builder != null) {
+                if (!predicate.remove(input, index, codeLen, env)) {
                     builder.append(input, index, index + codeLen);
                 }
                 index += codeLen;
@@ -366,64 +303,45 @@ public final class StringUtils {
         return builder == null ? input.toString() : builder.toString();
     }
 
-    /**
-     * @return {@code true} when the input contains any formatting codes understood by HexText.
-     */
-    public static boolean containsFormattingCodes(CharSequence input) {
-        return ColorCodeUtils.containsFormattingCodes(input);
-    }
+    private static TokenCategory classifyToken(CharSequence input, int index, int codeLen,
+                                               ColorCodeUtils.FormattingEnvironment env) {
+        if (codeLen <= 0 || index < 0 || index >= input.length()) {
+            return TokenCategory.OTHER;
+        }
 
-    private static boolean isHexColorToken(CharSequence input, int index, int codeLen) {
         char start = input.charAt(index);
+
         if (codeLen == 8 && (start == '&' || start == 167)) {
-            return true;
+            return TokenCategory.HEX_COLOR;
         }
 
-        final boolean htmlFormat = HexText.getActiveProxy() == null || HexText.getActiveProxy().allowHtmlFormatting();
-        final boolean ampersandFormat = HexText.getActiveProxy() == null
-            || HexText.getActiveProxy().allowUniversalAmpersand();
-
-        if (htmlFormat && codeLen == 8 && start == '<') {
-            return true;
+        boolean htmlAllowed = env == null || env.allowsHtmlFormatting();
+        if (htmlAllowed && start == '<' && (codeLen == 8 || codeLen == 9)) {
+            return TokenCategory.HEX_COLOR;
         }
 
-        if (htmlFormat && codeLen == 9 && start == '<') {
-            return true;
-        }
-
-        if (codeLen == 2 && ((start == '&' && ampersandFormat) || start == 167)) {
+        boolean ampersandAllowed = env == null || env.allowsUniversalAmpersand();
+        if (codeLen == 2 && ((start == '&' && ampersandAllowed) || start == 167)) {
             char fmt = Character.toLowerCase(input.charAt(index + 1));
-            return ColorCodeUtils.isMinecraftColorCode(fmt) || fmt == 'g';
-        }
-
-        return false;
-    }
-
-    private static boolean isStyleOrEffectToken(CharSequence input, int index, int codeLen) {
-        if (codeLen == 2) {
-            char start = input.charAt(index);
-            final boolean ampersandFormat = HexText.getActiveProxy() == null
-                || HexText.getActiveProxy().allowUniversalAmpersand();
-            if ((start == '&' && ampersandFormat) || start == 167) {
-                char fmt = Character.toLowerCase(input.charAt(index + 1));
-                return ColorCodeUtils.isStyleCode(fmt) || ColorCodeUtils.isEffectCode(fmt);
+            if (ColorCodeUtils.isMinecraftColorCode(fmt) || ColorCodeUtils.isRainbowCode(fmt)) {
+                return TokenCategory.STANDARD_COLOR;
+            }
+            if (ColorCodeUtils.isStyleCode(fmt) || ColorCodeUtils.isEffectCode(fmt)) {
+                return TokenCategory.STYLE_OR_EFFECT;
             }
         }
 
-        return false;
+        return TokenCategory.OTHER;
     }
 
-    private static boolean isStandardColorToken(CharSequence input, int index, int codeLen) {
-        if (codeLen == 2) {
-            char start = input.charAt(index);
-            final boolean ampersandFormat = HexText.getActiveProxy() == null
-                || HexText.getActiveProxy().allowUniversalAmpersand();
-            if ((start == '&' && ampersandFormat) || start == 167) {
-                char fmt = Character.toLowerCase(input.charAt(index + 1));
-                return ColorCodeUtils.isMinecraftColorCode(fmt) || fmt == 'g';
-            }
-        }
+    private interface TokenPredicate {
+        boolean remove(CharSequence sequence, int index, int length, ColorCodeUtils.FormattingEnvironment env);
+    }
 
-        return false;
+    private enum TokenCategory {
+        HEX_COLOR,
+        STANDARD_COLOR,
+        STYLE_OR_EFFECT,
+        OTHER
     }
 }

--- a/src/main/java/kamkeel/hextext/mixin/early/impl/client/MixinGuiTextField.java
+++ b/src/main/java/kamkeel/hextext/mixin/early/impl/client/MixinGuiTextField.java
@@ -79,6 +79,25 @@ public abstract class MixinGuiTextField extends Gui {
     }
 
     /**
+     * Skip drawing the prefix when raw mode rendering is active so subsequent full-string rendering
+     * does not apply token highlights twice.
+     */
+    @Redirect(
+        method = "drawTextBox",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/gui/FontRenderer;drawStringWithShadow(Ljava/lang/String;III)I",
+            ordinal = 0
+        )
+    )
+    private int hextext$skipPrefixInRaw(FontRenderer fontRenderer, String prefix, int x, int y, int color) {
+        if (HexText.getActiveProxy() != null && HexText.rawRenderingEnabled) {
+            return x;
+        }
+        return fontRenderer.drawStringWithShadow(prefix, x, y, color);
+    }
+
+    /**
      * In raw chat mode, when GuiTextField draws the suffix (text after cursor),
      * instead draw the full visible substring `s` so earlier colour codes still
      * affect the text after the cursor.

--- a/src/test/java/kamkeel/hextext/common/render/RenderTextProcessorTest.java
+++ b/src/test/java/kamkeel/hextext/common/render/RenderTextProcessorTest.java
@@ -150,7 +150,7 @@ public class RenderTextProcessorTest {
     public void testRainbowInstructionNonRaw() {
         RenderPlan data = RenderTextProcessor.prepare("&gRainbow", false);
         assertTrue(data.shouldReplaceText());
-        assertEquals("Rainbow", data.getDisplayText());
+        assertEquals("§gRainbow", data.getDisplayText());
         assertTrue(data.hasInstructions());
         List<RenderDirective> instructions = data.getInstructions().get(0);
         assertNotNull(instructions);
@@ -265,5 +265,46 @@ public class RenderTextProcessorTest {
         assertFalse(rgbData.hasInstructions());
         assertFalse(rgbData.shouldReplaceText());
         assertNull(rgbData.getDisplayText());
+    }
+
+    @Test
+    public void testEffectsStackWithStyles() {
+        RenderPlan data = RenderTextProcessor.prepare("&4&l&jTest", true);
+        assertTrue(data.hasInstructions());
+        Map<Integer, List<RenderDirective>> instructions = data.getInstructions();
+        assertNotNull(instructions);
+
+        List<RenderDirective> colorDirectives = instructions.get(0);
+        assertNotNull("Expected colour directive at index 0", colorDirectives);
+        boolean sawColor = false;
+        for (RenderDirective directive : colorDirectives) {
+            RenderDirectiveImpl renderDirective = (RenderDirectiveImpl) directive;
+            if (renderDirective.getType() == RenderDirectiveImpl.Type.APPLY_VANILLA_COLOR) {
+                sawColor = true;
+            }
+        }
+        assertTrue("Missing vanilla colour directive", sawColor);
+
+        List<RenderDirective> boldDirectives = instructions.get(2);
+        assertNotNull("Expected bold directive at index 2", boldDirectives);
+        boolean sawBold = false;
+        for (RenderDirective directive : boldDirectives) {
+            RenderDirectiveImpl renderDirective = (RenderDirectiveImpl) directive;
+            if (renderDirective.getType() == RenderDirectiveImpl.Type.SET_BOLD) {
+                sawBold = true;
+            }
+        }
+        assertTrue("Missing bold directive", sawBold);
+
+        List<RenderDirective> shakeDirectives = instructions.get(4);
+        assertNotNull("Expected shake directive at index 4", shakeDirectives);
+        boolean sawShake = false;
+        for (RenderDirective directive : shakeDirectives) {
+            RenderDirectiveImpl renderDirective = (RenderDirectiveImpl) directive;
+            if (renderDirective.getType() == RenderDirectiveImpl.Type.SET_SHAKE) {
+                sawShake = true;
+            }
+        }
+        assertTrue("Missing shake directive", sawShake);
     }
 }

--- a/src/test/java/kamkeel/hextext/common/util/ColorCodeUtilsTest.java
+++ b/src/test/java/kamkeel/hextext/common/util/ColorCodeUtilsTest.java
@@ -66,6 +66,20 @@ public class ColorCodeUtilsTest {
     }
 
     @Test
+    public void testRainbowClassification() {
+        assertTrue(ColorCodeUtils.isRainbowCode('g'));
+        assertFalse(ColorCodeUtils.isEffectCode('g'));
+        assertFalse(ColorCodeUtils.isRainbowCode('h'));
+    }
+
+    @Test
+    public void testDetectAmpersandFormattingCodeLength() {
+        assertEquals(2, ColorCodeUtils.detectAmpersandFormattingCodeLength("&aTest", 0));
+        assertEquals(8, ColorCodeUtils.detectAmpersandFormattingCodeLength("&#123456Test", 0));
+        assertEquals(0, ColorCodeUtils.detectAmpersandFormattingCodeLength("&x", 0));
+    }
+
+    @Test
     public void testCalculateShadowColor() {
         assertEquals(0x1E1E1E, ColorCodeUtils.calculateShadowColor(0x7A7A7A));
     }


### PR DESCRIPTION
## Summary
- consolidate formatting classification and ampersand token detection to eliminate duplicated helper logic
- refactor string stripping utilities to share token filtering and treat rainbow as a colour code that can stack with styles
- prevent duplicate raw-mode highlights by skipping the prefix draw and expand tests to cover stacking and formatting helpers

## Testing
- ./gradlew test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69153b1038e88323b76b529c8485f71d)