### PR TITLE
Refine render text formatting handling

### DIFF
--- a/src/main/java/kamkeel/hextext/common/render/RenderTextProcessor.java
+++ b/src/main/java/kamkeel/hextext/common/render/RenderTextProcessor.java
@@ -66,85 +66,35 @@ public final class RenderTextProcessor {
                 char lower = Character.toLowerCase(next);
 
                 if (ColorCodeUtils.isFormattingCode(lower)) {
-                    if (ColorCodeUtils.isEffectCode(lower)) {
+                    FormatCategory category = classifyFormatting(lower);
+                    if (category != null) {
                         directives = ensureDirectiveMap(directives);
                         List<RenderDirective> bucket =
                             directives.computeIfAbsent(directiveIndex, key -> new ArrayList<>());
-                        switch (lower) {
-                            case 'g':
-                                bucket.add(RenderDirectiveImpl.setRainbow(true, directiveIndex));
-                                break;
-                            case 'h':
-                                bucket.add(RenderDirectiveImpl.setDinnerbone(true));
-                                break;
-                            case 'i':
-                                bucket.add(RenderDirectiveImpl.setIgnite(true));
-                                break;
-                            case 'j':
-                                bucket.add(RenderDirectiveImpl.setShake(true));
-                                break;
-                            default:
-                                break;
+                        emitFormattingDirective(bucket, category, lower, directiveIndex);
+
+                        boolean usingLiteral = rawMode || usingSectionSign;
+                        if (usingLiteral) {
+                            sanitized.append(current);
+                            if (category.consumesTrailingCode()) {
+                                sanitized.append(next);
+                                i++;
+                            }
+                            continue;
                         }
-                        if (rawMode || usingSectionSign) {
-                            sanitized.append(current).append(next);
-                        } else {
+
+                        if (category.keepWhenUsingAmpersand()) {
+                            sanitized.append('§');
                             modified = true;
+                            continue;
                         }
-                        i++;
-                        continue;
-                    }
 
-                    boolean isReset = ColorCodeUtils.isResetCode(lower);
-                    boolean isColor = ColorCodeUtils.isMinecraftColorCode(lower);
-                    boolean isStyle = ColorCodeUtils.isStyleCode(lower);
-
-                    directives = ensureDirectiveMap(directives);
-                    List<RenderDirective> bucket =
-                        directives.computeIfAbsent(directiveIndex, key -> new ArrayList<>());
-
-                    if (isColor) {
-                        int colorIndex = ColorCodeUtils.getMinecraftColorIndex(lower);
-                        if (colorIndex >= 0) {
-                            bucket.add(RenderDirectiveImpl.applyVanillaColor(colorIndex));
-                        }
-                    } else if (isReset) {
-                        bucket.add(RenderDirectiveImpl.resetToBase());
-                    } else if (isStyle) {
-                        switch (lower) {
-                            case 'k':
-                                bucket.add(RenderDirectiveImpl.setRandom(true));
-                                break;
-                            case 'l':
-                                bucket.add(RenderDirectiveImpl.setBold(true));
-                                break;
-                            case 'm':
-                                bucket.add(RenderDirectiveImpl.setStrikethrough(true));
-                                break;
-                            case 'n':
-                                bucket.add(RenderDirectiveImpl.setUnderline(true));
-                                break;
-                            case 'o':
-                                bucket.add(RenderDirectiveImpl.setItalic(true));
-                                break;
-                            default:
-                                break;
-                        }
-                    }
-
-                    if (rawMode) {
-                        sanitized.append(current).append(next);
-                        i++;
-                        continue;
-                    }
-
-                    if (usingSectionSign) {
-                        sanitized.append(current);
-                    } else {
-                        sanitized.append('§');
                         modified = true;
+                        if (category.consumesTrailingCode()) {
+                            i++;
+                        }
+                        continue;
                     }
-                    continue;
                 }
             }
 
@@ -202,11 +152,118 @@ public final class RenderTextProcessor {
         return directives != null ? directives : new HashMap<>();
     }
 
+    private static FormatCategory classifyFormatting(char lower) {
+        if (ColorCodeUtils.isMinecraftColorCode(lower)) {
+            return FormatCategory.COLOR;
+        }
+        if (ColorCodeUtils.isResetCode(lower)) {
+            return FormatCategory.RESET;
+        }
+        if (ColorCodeUtils.isStyleCode(lower)) {
+            return FormatCategory.STYLE;
+        }
+        if (lower == 'g') {
+            return FormatCategory.RAINBOW;
+        }
+        if (ColorCodeUtils.isEffectCode(lower)) {
+            return FormatCategory.EFFECT;
+        }
+        return null;
+    }
+
+    private static void emitFormattingDirective(List<RenderDirective> bucket, FormatCategory category, char lower,
+        int directiveIndex) {
+        switch (category) {
+            case COLOR:
+                int colorIndex = ColorCodeUtils.getMinecraftColorIndex(lower);
+                if (colorIndex >= 0) {
+                    bucket.add(RenderDirectiveImpl.applyVanillaColor(colorIndex));
+                }
+                break;
+            case RESET:
+                bucket.add(RenderDirectiveImpl.resetToBase());
+                break;
+            case STYLE:
+                applyStyleDirective(bucket, lower);
+                break;
+            case EFFECT:
+                applyEffectDirective(bucket, lower);
+                break;
+            case RAINBOW:
+                bucket.add(RenderDirectiveImpl.setRainbow(true, directiveIndex));
+                break;
+            default:
+                break;
+        }
+    }
+
+    private static void applyStyleDirective(List<RenderDirective> bucket, char lower) {
+        switch (lower) {
+            case 'k':
+                bucket.add(RenderDirectiveImpl.setRandom(true));
+                break;
+            case 'l':
+                bucket.add(RenderDirectiveImpl.setBold(true));
+                break;
+            case 'm':
+                bucket.add(RenderDirectiveImpl.setStrikethrough(true));
+                break;
+            case 'n':
+                bucket.add(RenderDirectiveImpl.setUnderline(true));
+                break;
+            case 'o':
+                bucket.add(RenderDirectiveImpl.setItalic(true));
+                break;
+            default:
+                break;
+        }
+    }
+
+    private static void applyEffectDirective(List<RenderDirective> bucket, char lower) {
+        switch (lower) {
+            case 'h':
+                bucket.add(RenderDirectiveImpl.setDinnerbone(true));
+                break;
+            case 'i':
+                bucket.add(RenderDirectiveImpl.setIgnite(true));
+                break;
+            case 'j':
+                bucket.add(RenderDirectiveImpl.setShake(true));
+                break;
+            default:
+                break;
+        }
+    }
+
     private static Map<Integer, List<RenderDirective>> normalizeDirectives(
         Map<Integer, List<RenderDirective>> directives) {
         if (directives == null || directives.isEmpty()) {
             return null;
         }
         return directives;
+    }
+
+    private enum FormatCategory {
+        COLOR(true, false),
+        RESET(true, false),
+        STYLE(true, false),
+        EFFECT(false, true),
+        RAINBOW(false, true);
+
+        private final boolean keepWhenAmpersand;
+        private final boolean consumesTrailingCode;
+
+        FormatCategory(boolean keepWhenAmpersand, boolean consumesTrailingCode) {
+            this.keepWhenAmpersand = keepWhenAmpersand;
+            this.consumesTrailingCode = consumesTrailingCode;
+        }
+
+        boolean keepWhenUsingAmpersand() {
+            return keepWhenAmpersand;
+        }
+
+        boolean consumesTrailingCode() {
+            return consumesTrailingCode;
+        }
     }
 }

--- a/src/test/java/kamkeel/hextext/common/render/RenderTextProcessorTest.java
+++ b/src/test/java/kamkeel/hextext/common/render/RenderTextProcessorTest.java
@@ -286,6 +286,52 @@ public class RenderTextProcessorTest {
     }
 
     @Test
+    public void testStyleAndEffectsRemainAfterReorderingAmpersand() {
+        RenderPlan sequential = RenderTextProcessor.prepare("&e&l&i&jOk", false);
+        assertTrue(sequential.shouldReplaceText());
+        assertEquals("\u00A7e\u00A7lOk", sequential.getDisplayText());
+        assertInstructionTypes(sequential, 0, RenderDirectiveImpl.Type.APPLY_VANILLA_COLOR);
+        assertInstructionTypes(sequential, 2, RenderDirectiveImpl.Type.SET_BOLD);
+        assertInstructionTypes(sequential, 4, RenderDirectiveImpl.Type.SET_IGNITE, RenderDirectiveImpl.Type.SET_SHAKE);
+
+        RenderPlan interleaved = RenderTextProcessor.prepare("&e&j&i&lOk", false);
+        assertTrue(interleaved.shouldReplaceText());
+        assertEquals("\u00A7e\u00A7lOk", interleaved.getDisplayText());
+        assertInstructionTypes(interleaved, 0, RenderDirectiveImpl.Type.APPLY_VANILLA_COLOR);
+        assertInstructionTypes(interleaved, 2, RenderDirectiveImpl.Type.SET_SHAKE, RenderDirectiveImpl.Type.SET_IGNITE,
+            RenderDirectiveImpl.Type.SET_BOLD);
+    }
+
+    @Test
+    public void testStyleAndEffectsRemainAfterReorderingSectionSign() {
+        RenderPlan plan = RenderTextProcessor.prepare("§e§l§i§jOk", false);
+        assertFalse(plan.shouldReplaceText());
+        assertNull(plan.getDisplayText());
+        assertInstructionTypes(plan, 0, RenderDirectiveImpl.Type.APPLY_VANILLA_COLOR);
+        assertInstructionTypes(plan, 2, RenderDirectiveImpl.Type.SET_BOLD);
+        assertInstructionTypes(plan, 4, RenderDirectiveImpl.Type.SET_IGNITE);
+        assertInstructionTypes(plan, 6, RenderDirectiveImpl.Type.SET_SHAKE);
+    }
+
+    @Test
+    public void testRainbowResetsFormattingLikeColor() {
+        RenderPlan plan = RenderTextProcessor.prepare("&g&lOk", false);
+        assertTrue(plan.shouldReplaceText());
+        assertEquals("\u00A7lOk", plan.getDisplayText());
+        Map<Integer, List<RenderDirective>> instructions = plan.getInstructions();
+        assertNotNull(instructions);
+        List<RenderDirective> rainbowBucket = instructions.get(0);
+        assertNotNull(rainbowBucket);
+        assertTrue("Expected rainbow directive first", !rainbowBucket.isEmpty());
+        RenderDirectiveImpl rainbow = (RenderDirectiveImpl) rainbowBucket.get(0);
+        assertEquals(RenderDirectiveImpl.Type.SET_RAINBOW, rainbow.getType());
+        assertTrue(rainbow.shouldClearStack());
+        assertTrue(rainbow.resetsFormatting());
+        assertEquals("Expected bold instruction to follow rainbow", RenderDirectiveImpl.Type.SET_BOLD,
+            ((RenderDirectiveImpl) rainbowBucket.get(1)).getType());
+    }
+
+    @Test
     public void testRainbowFormattingProducesSectionSignOutput() {
         RenderPlan plan = RenderTextProcessor.prepare("&g&l&iTesting", false);
         assertTrue(plan.shouldReplaceText());
@@ -327,6 +373,18 @@ public class RenderTextProcessorTest {
         assertTrue("Expected bold instruction", sawBold);
         assertTrue("Expected ignite instruction", sawIgnite);
         assertTrue("Expected shake instruction", sawShake);
+    }
+
+    private void assertInstructionTypes(RenderPlan plan, int index, RenderDirectiveImpl.Type... expectedTypes) {
+        Map<Integer, List<RenderDirective>> instructions = plan.getInstructions();
+        assertNotNull("Expected instructions map", instructions);
+        List<RenderDirective> bucket = instructions.get(index);
+        assertNotNull("Expected bucket at index " + index, bucket);
+        assertEquals("Unexpected directive count at index " + index, expectedTypes.length, bucket.size());
+        for (int i = 0; i < expectedTypes.length; i++) {
+            RenderDirectiveImpl directive = (RenderDirectiveImpl) bucket.get(i);
+            assertEquals("Unexpected directive order at index " + index, expectedTypes[i], directive.getType());
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- refactor `RenderTextProcessor` to classify formatting codes, share effect/style handling, and treat rainbow as a formatting reset
- introduce helper routines for applying style and effect directives while keeping the prepare loop concise
- add regression tests covering style/effect ordering permutations and rainbow reset behaviour

## Testing
- ./gradlew test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915891366708323b6713899bf3e1718)